### PR TITLE
Fixing uplaod problem with rename method

### DIFF
--- a/src/FileUpload/FileSystem/Simple.php
+++ b/src/FileUpload/FileSystem/Simple.php
@@ -28,7 +28,7 @@ class Simple implements FileSystem {
    * @see FileSystem
    */
   public function moveUploadedFile($from_path, $to_path) {
-    return rename($from_path, $to_path);
+    return move_uploaded_file($from_path, $to_path);
   }
 
   /**


### PR DESCRIPTION
Hello,

there is a problem when /tmp dir is not on the same hard disk partition where I want to upload file. This is because php method `rename`. Quick solution is to use `move_uploaded_file` method instead of `rename`

Best,
Milos
P.S.
Your component is cool.
