### PR TITLE
Fixed todo messages in the MD5 filename generator 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
 
 before_script:
   - composer selfupdate

--- a/README.md
+++ b/README.md
@@ -93,8 +93,6 @@ $fileupload->setFileNameGenerator($filenamegenerator);
 
 We have placed some example generators like md5 who saves the file under the md5 hash of the filename or the random generator witch uses an random string. The default (the simple generator to be more precise) will save the file by its origin name.
 
-> The md5 Filename Generator would throw an exception - that is yours to catch - if the file exists in the directory..but  can be overridden by passing `true` as a parameter when creating the MD5 instance - It would overwrite the file without throwing an exception.
-
 ### Callbacks
 
 Currently implemented events:

--- a/README.md
+++ b/README.md
@@ -35,38 +35,38 @@ finishing.
 
 	// Simple validation (max file size 2MB and only two allowed mime types)
 	$validator = new FileUpload\Validator\Simple(1024 * 1024 * 2, ['image/png', 'image/jpg']);
-	
+
 	/**
 	*   For more flexibility, the simple Validator has been broken down since the size validator might not always be needed..
-	
+
 		$mimeTypeValidator = new \FileUpload\Validator\MimeTypeValidator(["image/png", "image/jpeg"]);
-        
+
         $sizeValidator = new \FileUpload\Validator\SizeValidator("3M", "1M"); //the 1st parameter is the max size while the 2nd id the min size
 
 	**/
-	
+
 	// Simple path resolver, where uploads will be put
 	$pathresolver = new FileUpload\PathResolver\Simple('/my/uploads/dir');
-	
+
 	// The machine's filesystem
 	$filesystem = new FileUpload\FileSystem\Simple();
-	
+
 	// FileUploader itself
 	$fileupload = new FileUpload\FileUpload($_FILES['files'], $_SERVER);
-	
+
 	// Adding it all together. Note that you can use multiple validators or none at all
 	$fileupload->setPathResolver($pathresolver);
 	$fileupload->setFileSystem($filesystem);
 	$fileupload->addValidator($validator);
-	
+
 	// Doing the deed
 	list($files, $headers) = $fileupload->processAll();
-	
+
 	// Outputting it, for example like this
 	foreach($headers as $header => $value) {
 	  header($header . ': ' . $value);
 	}
-	
+
 	echo json_encode(array('files' => $files));
 
 ```
@@ -83,15 +83,17 @@ Here is a listing of the possible values (B => B; KB => K; MB => M; GB => G). Th
 
 ### FileNameGenerator  
 
-With the FileNameGenerator you have the possibility to change the Filename the uploaded files will be saved as. 
+With the FileNameGenerator you have the possibility to change the Filename the uploaded files will be saved as.
 
-``` 
+```
 $fileupload = new FileUpload\FileUpload($_FILES['files'], $_SERVER);
 $filenamegenerator = new FileUpload\FileNameGenerator\Simple();
 $fileupload->setFileNameGenerator($filenamegenerator);
 ```
 
 We have placed some example generators like md5 who saves the file under the md5 hash of the filename or the random generator witch uses an random string. The default (the simple generator to be more precise) will save the file by its origin name.
+
+> The md5 Filename Generator would throw an exception - that is yours to catch - if the file exists in the directory..but  can be overridden by passing `true` as a parameter when creating the MD5 instance - It would overwrite the file without throwing an exception.
 
 ### Callbacks
 
@@ -107,7 +109,7 @@ $fileupload->addCallback('completed', function(FileUpload\File $file) {
 
 * `beforeValidation`
 
-```php 
+```php
     $fileUploader->addCallback('beforeValidation', function (FileUpload\File $file
     ) {
         //about to validate the upload;

--- a/src/FileUpload/FileNameGenerator/FileNameGenerator.php
+++ b/src/FileUpload/FileNameGenerator/FileNameGenerator.php
@@ -2,6 +2,8 @@
 
 namespace FileUpload\FileNameGenerator;
 
+use FileUpload\FileUpload;
+
 interface FileNameGenerator {
 
     /**
@@ -11,10 +13,9 @@ interface FileNameGenerator {
      * @param  string       $tmp_name
      * @param  integer      $index
      * @param  string       $content_range
-     * @param  Pathresolver $pathresolver
-     * @param  Filesystem   $filesystem
+     * @param  FileUpload   $upload
      * @return string
      */
-    public function getFileName($source_name, $type, $tmp_name, $index, $content_range, $pathresolver, $filesystem);
+    public function getFileName($source_name, $type, $tmp_name, $index, $content_range,FileUpload $upload);
 
 }

--- a/src/FileUpload/FileNameGenerator/MD5.php
+++ b/src/FileUpload/FileNameGenerator/MD5.php
@@ -2,8 +2,26 @@
 
 namespace FileUpload\FileNameGenerator;
 
+use FileUpload\Validator\Simple;
+use FileUpload\FileUpload;
 
-class MD5 implements FileNameGenerator {
+class MD5 implements FileNameGenerator
+{
+
+    /**
+     * Should we allow files with the same MD5'd name ?
+     * @var bool
+     */
+    protected $allowDuplicate ;
+
+    /**
+     * If $allowDuplicate is set to false - which is the default - files having the same md5'd name would be overwritten. {@see Simple}
+     * @param bool $allowDuplicate allows the library user determine it's behaviour
+     */
+    public function __construct($allowDuplicate = false)
+    {
+        $this->allowDuplicate = (bool) $allowDuplicate ;
+    }
 
     /**
      * Get file_name
@@ -14,14 +32,20 @@ class MD5 implements FileNameGenerator {
      * @param  string       $content_range
      * @param  Pathresolver $pathresolver
      * @param  Filesystem   $filesystem
-     * @return string
+     * @return bool|string if $allowDuplicate is set to false and a file with the same Md5'd name exists in the upload directory, then a bool is returned.
      */
-    public function getFileName($source_name, $type, $tmp_name, $index, $content_range, $pathresolver, $filesystem)
+    public function getFileName($source_name, $type, $tmp_name, $index, $content_range, FileUpload $upload)
     {
-        $filename = substr($source_name, 0, strrpos($source_name, '.'));
-        $extension = substr($source_name, strrpos($source_name, '.')+1);
-        return(md5($filename).".".$extension);
-    }
+        $filename = pathinfo($source_name , PATHINFO_FILENAME);
+        $extension = pathinfo($source_name , PATHINFO_EXTENSION);
 
-    //TODO Add duplicate filename check
+        $md5ConcatenatedName = md5($filename).".".$extension;
+
+        if($upload->getFileSystem()->doesFileExist($upload->getPathResolver()->getUploadPath( $md5ConcatenatedName)) && $this->allowDuplicate === false) {
+            $upload->getFileContainer()->error = "File already exist in the upload directory. Please upload another file or change it's name";
+            return false ;
+        }
+
+        return $md5ConcatenatedName ;
+    }
 }

--- a/src/FileUpload/FileNameGenerator/Random.php
+++ b/src/FileUpload/FileNameGenerator/Random.php
@@ -4,6 +4,7 @@
 namespace FileUpload\FileNameGenerator;
 
 use FileUpload\Util;
+use FileUpload\FileUpload;
 
 class Random implements FileNameGenerator {
 
@@ -36,15 +37,14 @@ class Random implements FileNameGenerator {
      * @param  string       $tmp_name
      * @param  integer      $index
      * @param  string       $content_range
-     * @param  Pathresolver $pathresolver
-     * @param  Filesystem   $filesystem
+     * @param  FileUpload   $upload
      * @return string
      */
-    public function getFileName($source_name, $type, $tmp_name, $index, $content_range, $pathresolver, $filesystem)
+    public function getFileName($source_name, $type, $tmp_name, $index, $content_range, FileUpload $upload)
     {
-        $this->pathresolver = $pathresolver;
-        $this->filesystem = $filesystem;
-        $extension = substr($source_name, strrpos($source_name, '.')+1);
+        $this->pathresolver = $upload->getPathResolver();
+        $this->filesystem = $upload->getFileSystem();
+        $extension = pathinfo($source_name , PATHINFO_EXTENSION);
         return($this->getUniqueFilename($source_name, $type, $index, $content_range, $extension));
     }
 

--- a/src/FileUpload/FileNameGenerator/Simple.php
+++ b/src/FileUpload/FileNameGenerator/Simple.php
@@ -10,6 +10,7 @@ namespace FileUpload\FileNameGenerator;
 
 use FileUpload\FileSystem\FileSystem;
 use FileUpload\PathResolver\PathResolver;
+use FileUpload\FileUpload;
 use FileUpload\Util;
 
 class Simple implements FileNameGenerator {
@@ -33,14 +34,13 @@ class Simple implements FileNameGenerator {
      * @param  string       $tmp_name
      * @param  integer      $index
      * @param  string       $content_range
-     * @param  Pathresolver $pathresolver
-     * @param  Filesystem   $filesystem
+     * @param  FileUpload   $upload
      * @return string
      */
-    public function getFileName($source_name, $type, $tmp_name, $index, $content_range, $pathresolver, $filesystem)
+    public function getFileName($source_name, $type, $tmp_name, $index, $content_range, FileUpload $upload)
     {
-        $this->filesystem = $filesystem;
-        $this->pathresolver = $pathresolver;
+        $this->filesystem = $upload->getFileSystem();
+        $this->pathresolver = $upload->getPathResolver();
 
         return($this->getUniqueFilename($source_name, $type, $index, $content_range));
     }

--- a/src/FileUpload/FileSystem/FileSystem.php
+++ b/src/FileUpload/FileSystem/FileSystem.php
@@ -24,6 +24,14 @@ interface FileSystem {
    */
   public function isUploadedFile($path);
 
+
+  /**
+   * Check if the file exists in a specified directory {@see __construct}
+   * @param  string $path File to be checked.
+   * @return boolean
+   */
+  public function doesFileExist($path);
+
   /**
    * Move file
    * @param  string  $from_path

--- a/src/FileUpload/FileSystem/Mock.php
+++ b/src/FileUpload/FileSystem/Mock.php
@@ -25,6 +25,14 @@ class Mock implements FileSystem {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function doesFileExist($path)
+  {
+      return file_exists($path) ? true : false ;
+  }
+
+  /**
    * @see FileSystem
    */
   public function moveUploadedFile($from_path, $to_path) {

--- a/src/FileUpload/FileSystem/Simple.php
+++ b/src/FileUpload/FileSystem/Simple.php
@@ -25,6 +25,14 @@ class Simple implements FileSystem {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function doesFileExist($path)
+  {
+      return file_exists($path) ? true : false ;
+  }
+
+  /**
    * @see FileSystem
    */
   public function moveUploadedFile($from_path, $to_path) {

--- a/src/FileUpload/FileUpload.php
+++ b/src/FileUpload/FileUpload.php
@@ -7,6 +7,7 @@ use FileUpload\FileNameGenerator\Simple;
 use FileUpload\PathResolver\PathResolver;
 use FileUpload\FileSystem\FileSystem;
 use FileUpload\Validator\Validator;
+use FileUpload\File;
 use Psr\Log\LoggerInterface;
 
 class FileUpload
@@ -54,6 +55,12 @@ class FileUpload
     protected $logger;
 
     /**
+     * File Container instance
+     * @var File
+     */
+    protected $fileContainer ;
+
+    /**
      * Validators to be run
      * @var array
      */
@@ -99,6 +106,7 @@ class FileUpload
         $this->upload = isset($upload) ? $upload : null;
         $this->server = $server;
         $this->filename_generator = $generator ?: new Simple();
+        $this->fileContainer = new File();
     }
 
     /**
@@ -167,6 +175,14 @@ class FileUpload
     public function getLogger()
     {
         return $this->logger;
+    }
+
+    /**
+     * @return File
+     */
+    public function getFileContainer()
+    {
+        return $this->fileContainer;
     }
 
     /**
@@ -282,7 +298,7 @@ class FileUpload
                 $content_range
             );
         } else if ($upload && $upload['error'] != 0) {
-            $file = new File();
+            $file = $this->getFileContainer();
             $file->error = $this->messages[$upload['error']];
             $file->error_code = $upload['error'];
             $this->files[] = $file;
@@ -340,55 +356,58 @@ class FileUpload
      */
     protected function process($tmp_name, $name, $size, $type, $error, $index = 0, $content_range = null)
     {
-        $file = new File;
+        $file = $this->getFileContainer();
         $file->name = $this->getFilename($name, $type, $index, $content_range, $tmp_name);
         $file->size = $this->fixIntegerOverflow(intval($size));
         $file->setTypeFromPath($tmp_name);
 
-        if ($this->validate($tmp_name, $file, $error, $index)) {
-            // Now that we passed the validation, we can work with the file
-            $upload_path = $this->pathresolver->getUploadPath();
-            $file_path = $this->pathresolver->getUploadPath($file->name);
-            $append_file = $content_range && $this->filesystem->isFile($file_path) && $file->size > $this->getFilesize($file_path);
+        if ($file->name) { //since the md5 filename generator would return false if it's allowDuplicate property is set to false and the file already exists.
 
-            if ($tmp_name && $this->filesystem->isUploadedFile($tmp_name)) {
-                // This is a normal upload from temporary file
-                if ($append_file) {
-                    // Adding to existing file (chunked uploads)
-                    $this->filesystem->writeToFile($file_path, $this->filesystem->getFileStream($tmp_name), true);
+            if ($this->validate($tmp_name, $file, $error, $index)) {
+                // Now that we passed the validation, we can work with the file
+                $upload_path = $this->pathresolver->getUploadPath();
+                $file_path = $this->pathresolver->getUploadPath($file->name);
+                $append_file = $content_range && $this->filesystem->isFile($file_path) && $file->size > $this->getFilesize($file_path);
+
+                if ($tmp_name && $this->filesystem->isUploadedFile($tmp_name)) {
+                    // This is a normal upload from temporary file
+                    if ($append_file) {
+                        // Adding to existing file (chunked uploads)
+                        $this->filesystem->writeToFile($file_path, $this->filesystem->getFileStream($tmp_name), true);
+                    } else {
+                        // Upload full file
+                        $this->filesystem->moveUploadedFile($tmp_name, $file_path);
+                    }
                 } else {
-                    // Upload full file
-                    $this->filesystem->moveUploadedFile($tmp_name, $file_path);
+                    // This is a PUT-type upload
+                    $this->filesystem->writeToFile($file_path, $this->filesystem->getInputStream(), $append_file);
                 }
-            } else {
-                // This is a PUT-type upload
-                $this->filesystem->writeToFile($file_path, $this->filesystem->getInputStream(), $append_file);
-            }
 
-            $file_size = $this->getFilesize($file_path, $append_file);
+                $file_size = $this->getFilesize($file_path, $append_file);
 
-            if ($this->logger) {
-                $this->logger->debug('Processing ' . $file->name, array(
-                    'File path' => $file_path,
-                    'File object' => $file,
-                    'Append to file?' => $append_file,
-                    'File exists?' => $this->filesystem->isFile($file_path),
-                    'File size' => $file_size,
-                ));
-            }
+                if ($this->logger) {
+                    $this->logger->debug('Processing ' . $file->name, array(
+                        'File path' => $file_path,
+                        'File object' => $file,
+                        'Append to file?' => $append_file,
+                        'File exists?' => $this->filesystem->isFile($file_path),
+                        'File size' => $file_size,
+                    ));
+                }
 
-            if ($file->size == $file_size) {
-                // Yay, upload is complete!
-                $file->path = $file_path;
-                $file->completed = true;
-                $this->processCallbacksFor('completed', $file);
-            } else {
-                $file->size = $file_size;
+                if ($file->size == $file_size) {
+                    // Yay, upload is complete!
+                    $file->path = $file_path;
+                    $file->completed = true;
+                    $this->processCallbacksFor('completed', $file);
+                } else {
+                    $file->size = $file_size;
 
-                if (!$content_range) {
-                    // The file is incomplete and it's not a chunked upload, abort
-                    $this->filesystem->unlink($file_path);
-                    $file->error = 'abort';
+                    if (!$content_range) {
+                        // The file is incomplete and it's not a chunked upload, abort
+                        $this->filesystem->unlink($file_path);
+                        $file->error = 'abort';
+                    }
                 }
             }
         }

--- a/src/FileUpload/FileUpload.php
+++ b/src/FileUpload/FileUpload.php
@@ -92,12 +92,13 @@ class FileUpload
      * Construct this mother
      * @param array $upload
      * @param array $server
+     * @param FileNameGenerator $generator
      */
-    public function __construct($upload, $server)
+    public function __construct($upload, $server , FileNameGenerator $generator = null)
     {
         $this->upload = isset($upload) ? $upload : null;
         $this->server = $server;
-        $this->filename_generator = new Simple();
+        $this->filename_generator = $generator ?: new Simple();
     }
 
     /**
@@ -110,12 +111,28 @@ class FileUpload
     }
 
     /**
+     * @return PathResolver
+     */
+    public function getPathResolver()
+    {
+        return $this->pathresolver;
+    }
+
+    /**
      * Set filename generator
      * @param FileNameGenerator $fng
      */
     public function setFileNameGenerator(FileNameGenerator $fng)
     {
         $this->filename_generator = $fng;
+    }
+
+    /**
+     * @return FileNameGenerator
+     */
+    public function getFileNameGenerator()
+    {
+        return $this->filename_generator;
     }
 
     /**
@@ -128,12 +145,28 @@ class FileUpload
     }
 
     /**
+     * @return FileSystem
+     */
+    public function getFileSystem()
+    {
+        return $this->filesystem;
+    }
+
+    /**
      * Set logger, optionally
      * @param LoggerInterface $logger
      */
     public function setLogger(LoggerInterface $logger)
     {
         $this->logger = $logger;
+    }
+
+    /**
+     * @return LoggerInterface
+     */
+    public function getLogger()
+    {
+        return $this->logger;
     }
 
     /**
@@ -391,7 +424,7 @@ class FileUpload
     protected function getFilename($name, $type, $index, $content_range, $tmp_name)
     {
         $name = $this->trimFilename($name, $type, $index, $content_range);
-        return ($this->filename_generator->getFileName($name, $type, $tmp_name, $index, $content_range, $this->pathresolver, $this->filesystem));
+        return ($this->filename_generator->getFileName($name, $type, $tmp_name, $index, $content_range,$this));
     }
 
     /**

--- a/tests/FileUpload/FileNameGenerator/MD5Test.php
+++ b/tests/FileUpload/FileNameGenerator/MD5Test.php
@@ -2,23 +2,37 @@
 
 namespace FileUpload\FileNameGenerator;
 
+use FileUpload\FileSystem\Mock;
 use FileUpload\FileSystem\Simple;
+use FileUpload\FileUpload;
+use FileUpload\PathResolver\Simple as Path;
 
-class MD5Test extends \PHPUnit_Framework_TestCase {
+class MD5Test extends \PHPUnit_Framework_TestCase
+{
     protected $filesystem;
 
-    public function setUp() {
+    public function setUp()
+    {
 
     }
 
-    public function testGenerator() {
+    public function testGenerator()
+    {
 
         $generator = new MD5();
+        $playground_path = __DIR__ . '/../playground';
 
         $filename = "picture.jpg";
         $new_filename = md5("picture").".jpg";
 
-        $this->assertEquals($generator->getFileName($filename, "image/jpg", "asdf.jpg", 0, "100", new \FileUpload\PathResolver\Simple(''), new Simple()), $new_filename);
+        $server = array('CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321);
+        $file   = array('tmp_name' => $playground_path . '/real-image.jpg', 'name' => 'real-image.jpg', 'size' => 30321, 'type' => 'image/jpg', 'error' => 0);
+
+        $fileUpload = new FileUpload($file, $server, $generator);
+        $fileUpload->setFileSystem(new Mock());
+        $fileUpload->setPathResolver(new Path($playground_path."/uploaded"));
+
+        $this->assertEquals($generator->getFileName($filename, "image/jpg", "asdf.jpg", 0, "100",$fileUpload), $new_filename);
 
     }
 

--- a/tests/FileUpload/FileNameGenerator/RandomTest.php
+++ b/tests/FileUpload/FileNameGenerator/RandomTest.php
@@ -4,15 +4,19 @@ namespace FileUpload\FileNameGenerator;
 
 use FileUpload\FileSystem\Mock;
 use FileUpload\PathResolver\Simple;
+use FileUpload\FileUpload;
 
-class RandomTest extends \PHPUnit_Framework_TestCase {
+class RandomTest extends \PHPUnit_Framework_TestCase
+{
     protected $filesystem;
 
-    public function setUp() {
+    public function setUp()
+    {
 
     }
 
-    public function testGenerator() {
+    public function testGenerator()
+    {
 
         $generator = new Random(32);
 
@@ -22,7 +26,14 @@ class RandomTest extends \PHPUnit_Framework_TestCase {
         $filesystem = new Mock();
         $resolver   = new Simple($playground_path . '/uploaded');
 
-        $new_name = $generator->getFileName($filename, "image/jpg", "asdf.jpg", 0, "100", $resolver, $filesystem);
+        $server = array('CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321);
+        $file   = array('tmp_name' => $playground_path . '/real-image.jpg', 'name' => 'real-image.jpg', 'size' => 30321, 'type' => 'image/jpg', 'error' => 0);
+
+        $fileUpload = new FileUpload($file , $server , $generator);
+        $fileUpload->setPathResolver($resolver);
+        $fileUpload->setFileSystem($filesystem);
+
+        $new_name = $generator->getFileName($filename, "image/jpg", "asdf.jpg", 0, "100", $fileUpload);
 
         $this->assertEquals(32, strrpos($new_name, "."));
         $this->assertEquals(substr($new_name, strrpos($new_name, ".")), ".jpg");

--- a/tests/FileUpload/FileNameGenerator/SimpleTest.php
+++ b/tests/FileUpload/FileNameGenerator/SimpleTest.php
@@ -7,14 +7,17 @@ use FileUpload\FileUpload;
 use FileUpload\PathResolver\Simple;
 use FileUpload\FileNameGenerator\Simple as SimpleGenerator;
 
-class SimpleTest extends \PHPUnit_Framework_TestCase {
+class SimpleTest extends \PHPUnit_Framework_TestCase
+{
     protected $filesystem;
 
-    public function setUp() {
+    public function setUp()
+    {
 
     }
 
-    public function testGenerator() {
+    public function testGenerator()
+    {
 
         $generator = new SimpleGenerator();
         $playground_path = __DIR__ . '/../playground';
@@ -22,9 +25,16 @@ class SimpleTest extends \PHPUnit_Framework_TestCase {
         $filesystem = new Mock();
         $resolver   = new Simple($playground_path . '/uploaded');
 
+        $server = array('CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321);
+        $file   = array('tmp_name' => $playground_path . '/real-image.jpg', 'name' => 'real-image.jpg', 'size' => 30321, 'type' => 'image/jpg', 'error' => 0);
+
+        $fileUpload = new FileUpload($file , $server , $generator);
+        $fileUpload->setPathResolver($resolver);
+        $fileUpload->setFileSystem($filesystem);
+
         $filename = "picture.jpg";
 
-        $this->assertEquals($generator->getFileName($filename, "image/jpg", "asdf.jpg", 0, 100 ,$resolver, $filesystem), $filename);
+        $this->assertEquals($generator->getFileName($filename, "image/jpg", "asdf.jpg", 0, 100 ,$fileUpload), $filename);
 
     }
 


### PR DESCRIPTION
The md5 generator now checks if the file already exists on the file system and would either allow the upload to go through or not depending on the `overwrite` variable in it's constructor is configured.

I also removed duplicated codes.... `new File()` could be found more than once in the `FileUpload` class plus a new method `doesFileExists` for the file-system.

Lastly, i figured a way to reduce method parameter bloat by introducing getters for the path resolver, filesystem objects in the `FileUpload` class