### PR TITLE
Fixed composer requirement string

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This package is available via Composer:
 ```json
 {
   "require": {
-    "gargron/fileupload": "~1.1.*"
+    "gargron/fileupload": "~1.1.1"
   }
 }
 ```


### PR DESCRIPTION
You can use either `~1.1.1` or `1.1.*` notation, but not `~1.1.*`