### PR TITLE
New Validator --- Dimension validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,6 @@ You can grep the source code for "TODO" to find things you could help finishing.
 // Simple validation (max file size 2MB and only two allowed mime types)
 $validator = new FileUpload\Validator\Simple(1024 * 1024 * 2, ['image/png', 'image/jpg']);
 
-// Alternatively, if you don't want to validate both size and type at the same time, you could use:
-$mimeTypeValidator = new \FileUpload\Validator\MimeTypeValidator(["image/png", "image/jpeg"]);
-
-// And/or (the 1st parameter is the max size while the 2nd is the min size):
-$sizeValidator = new \FileUpload\Validator\SizeValidator("3M", "1M");
-
 // Simple path resolver, where uploads will be put
 $pathresolver = new FileUpload\PathResolver\Simple('/my/uploads/dir');
 
@@ -85,7 +79,44 @@ $factory = new FileUploadFactory(new PathResolver\Simple('/my/uploads/dir'), new
 $instance = $factory->create($_FILES['files'], $_SERVER);
 ```
 
-### Validator
+### Validators
+
+There are currently 4 validators shipped with `FileUpload` :
+
+ - `Simple`
+ 
+ ```php
+ // Simple validation (max file size 2MB and only two allowed mime types)
+ $validator = new FileUpload\Validator\Simple(1024 * 1024 * 2, ['image/png', 'image/jpg']);
+
+ ```
+
+ - `MimeTypeValidator` 
+
+ ```php
+ $mimeTypeValidator = new \FileUpload\Validator\MimeTypeValidator(["image/png", "image/jpeg"]);
+ ```
+
+- `SizeValidator`
+```php
+// The 1st parameter is the maximum size while the 2nd is the minimum size
+$sizeValidator = new \FileUpload\Validator\SizeValidator("3M", "1M");
+```
+
+- `DimensionValidator`
+
+```php
+
+$config = [
+  'width' => 400,
+  'height' => 500
+]; //can also contain "min_width", "max_width", "min_height" and "max_height"
+
+$dimensionValidator = new \FileUpload\Validator\DimensionValidator($config);
+
+```
+
+> Remember to register new validator(s) by `$fileuploadInstance->addValidator($validator);`
 
 If you want you can use the common human readable format for filesizes like "1M", "1G", just pass the String as the first Argument.
 

--- a/src/FileUpload/FileUpload.php
+++ b/src/FileUpload/FileUpload.php
@@ -344,7 +344,7 @@ class FileUpload
 
                 if ($file->size == $file_size) {
                     // Yay, upload is complete!
-                    $file->completed = true;
+                    $completed = true;
                     $this->processCallbacksFor('completed', $file);
                 } else {
                     $file->size = $file_size;
@@ -358,7 +358,12 @@ class FileUpload
             }
         }
 
-        return new $file($file_path);
+        //This is re-instantiated so as to allow \SplFileInfo pick up metadata about the uploaded file
+        $fileInfo = new $file($file_path);
+
+        $fileInfo->completed = $completed ?: false;
+
+        return $fileInfo;
     }
 
     /**

--- a/src/FileUpload/Validator/DimensionValidator.php
+++ b/src/FileUpload/Validator/DimensionValidator.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace FileUpload\Validator;
+
+use FileUpload\File;
+
+class DimensionValidator implements Validator
+{
+
+    const INVALID_UPLOADED_FILE_TYPE = 0;
+
+    const WIDTH = 'width';
+    const MAX_WIDTH = 'max_width';
+    const MIN_WIDTH = 'min_width';
+    const HEIGHT = 'height';
+    const MAX_HEIGHT = 'max_height';
+    const MIN_HEIGHT = 'min_height';
+
+    protected $config;
+
+    protected $errorMessages = array(
+
+        self::INVALID_UPLOADED_FILE_TYPE => "Cannot validate the currently uploaded file by it's dimension as it is not an image",
+
+        self::HEIGHT => "The uploaded file's height is invalid. It should have an height of {value}",
+
+        self::MIN_HEIGHT => "The uploaded file's height is too small. It should have a minimum height of {value}",
+
+        self::MAX_HEIGHT => "The uploaded file's height is too large. It should have a maximum height of {value}",
+
+        self::WIDTH => "The uploaded file's width is invalid. It should have an height of {value}",
+
+        self::MIN_WIDTH => "The uploaded file's width is too small. It should have a minimum height of {value}",
+
+        self::MAX_WIDTH => "The uploaded file's width is too large. It should have a maximum height of {value}"
+    );
+
+    public function __construct(array $config)
+    {
+        $this->config = $config;
+    }
+
+    public function setErrorMessages(array $message)
+    {
+        foreach ($message as $key => $value) {
+            $this->errorMessages[$key] = $value;
+        }
+    }
+
+    public function validate(File $file, $currentSize = null)
+    {
+
+        if (!$file->isImage() || !list($width, $height) = getimagesize($file->getRealPath())) {
+            $file->error = $this->errorMessages[self::INVALID_UPLOADED_FILE_TYPE];
+
+            return false;
+        }
+
+        return $this->validateDimensions($file, $width, $height);
+    }
+
+    protected function validateDimensions(File $file, $width, $height)
+    {
+        $valid = true;
+
+        //Multiple if/else here so as to allow proper message formatting.
+        //All can be lumped up in one big if check but the error message would be poor.
+        //Plus that would defeat the ability of users setting up custom error messages
+
+        if (isset($this->config[self::WIDTH]) && $this->config[self::WIDTH] !== $width) {
+            $file->error = $this->formatErrorMessage(self::WIDTH, $width);
+            $valid = false;
+        }
+
+        if (isset($this->config[self::MIN_WIDTH]) && $this->config[self::MIN_WIDTH] > $width) {
+            $file->error = $this->formatErrorMessage(self::MIN_WIDTH, $width);
+            $valid = false;
+        }
+
+        if (isset($this->config[self::MAX_WIDTH]) && $this->config[self::MAX_WIDTH] < $width) {
+            $file->error = $this->formatErrorMessage(self::MAX_WIDTH, $width);
+            $valid = false;
+        }
+
+        if (isset($this->config[self::HEIGHT]) && $this->config[self::HEIGHT] !== $height) {
+            $file->error = $this->formatErrorMessage(self::HEIGHT, $height);
+            $valid = false;
+        }
+
+        if (isset($this->config[self::MIN_HEIGHT]) && $this->config[self::MIN_HEIGHT] > $height) {
+            $file->error = $this->formatErrorMessage(self::MIN_HEIGHT, $height);
+            $valid = false;
+        }
+
+        if (isset($this->config[self::MAX_HEIGHT]) && $this->config[self::MAX_HEIGHT] < $height) {
+            $file->error = $this->formatErrorMessage(self::MAX_HEIGHT, $height);
+            $valid = false;
+        }
+
+        return $valid;
+    }
+
+    protected function formatErrorMessage($key, $heightValue)
+    {
+        return $this->errorMessages[$key] = str_replace(
+            "{value}",
+            $heightValue,
+            $this->errorMessages[$key]
+        );
+    }
+}

--- a/tests/FileUpload/Validator/DimensionValidatorTest.php
+++ b/tests/FileUpload/Validator/DimensionValidatorTest.php
@@ -1,0 +1,306 @@
+<?php
+
+namespace FileUpload\Validator;
+
+
+use FileUpload\File;
+
+class DimensionValidatorTest extends \PHPUnit_Framework_TestCase
+{
+
+    protected $directory;
+
+    public function testOnlyAnImageCanBeValidated()
+    {
+        $_FILES['file'] = array(
+            "name" => "fake-image.jpg",
+            "tmp_name" => $this->directory . 'fake-image.jpg',
+            "size" => 12,
+            "error" => 0
+        );
+
+        $file = new File($_FILES['file']['tmp_name']);
+
+        $config = array(
+            'width' => 100,
+            'height' => 200
+        );
+
+        $this->assertFalse(
+            $this->createValidator($config)
+                ->validate($file, $_FILES['file']['size'])
+        );
+
+        $this->assertEquals(
+            'Cannot validate the currently uploaded file by it\'s dimension as it is not an image',
+            $file->error
+        );
+    }
+
+    protected function createValidator(array $config)
+    {
+        return new DimensionValidator($config);
+    }
+
+    public function testValidatorWorksWithTheWidthConfig()
+    {
+        $_FILES['file'] = array(
+            "name" => "real-image.jpg",
+            "tmp_name" => $this->directory . 'real-image.jpg',
+            "size" => 12,
+            "error" => 0
+        );
+
+        $file = new File($_FILES['file']['tmp_name']);
+
+        $config = array(
+            'width' => 300
+        );
+
+        $this->assertTrue(
+            $this->createValidator($config)
+                ->validate($file, $_FILES['file']['size'])
+        );
+
+        $config = array(
+            'width' => 302
+        );
+
+        $this->assertFalse(
+            $this->createValidator($config)
+                ->validate($file, $_FILES['file']['size'])
+        );
+    }
+
+    public function testValidatorWorksWithTheMinimumWidthConfig()
+    {
+        $_FILES['file'] = array(
+            "name" => "real-image.jpg",
+            "tmp_name" => $this->directory . 'real-image.jpg',
+            "size" => 12,
+            "error" => 0
+        );
+
+        $file = new File($_FILES['file']['tmp_name']);
+
+        $config = array(
+            'min_width' => 200
+        );
+
+        $this->assertTrue(
+            $this->createValidator($config)
+                ->validate($file, $_FILES['file']['size'])
+        );
+
+        $config = array(
+            'min_width' => 301
+        );
+
+        $this->assertFalse(
+            $this->createValidator($config)
+                ->validate($file, $_FILES['file']['size'])
+        );
+    }
+
+    public function testValidatorWorksWithTheMaximumWidthConfig()
+    {
+        $_FILES['file'] = array(
+            "name" => "real-image.jpg",
+            "tmp_name" => $this->directory . 'real-image.jpg',
+            "size" => 12,
+            "error" => 0
+        );
+
+        $file = new File($_FILES['file']['tmp_name']);
+
+        $config = array(
+            'max_width' => 400
+        );
+
+        $this->assertTrue(
+            $this->createValidator($config)
+                ->validate($file, $_FILES['file']['size'])
+        );
+
+        $config = array(
+            'max_width' => 250
+        );
+
+        $this->assertFalse(
+            $this->createValidator($config)
+                ->validate($file, $_FILES['file']['size'])
+        );
+    }
+
+    public function testValidatorWorksExpectedlyWithTheWidthAndHeightValues()
+    {
+        $_FILES['file'] = array(
+            "name" => "real-image.jpg",
+            "tmp_name" => $this->directory . 'real-image.jpg',
+            "size" => 12,
+            "error" => 0
+        );
+
+        $file = new File($_FILES['file']['tmp_name']);
+
+        $config = array(
+            'width' => 300,
+            'height' => 300
+        );
+
+        $this->assertTrue(
+            $this->createValidator($config)
+                ->validate($file, $_FILES['file']['size'])
+        );
+    }
+
+    public function testValidatorWorksWithTheHeightConfig()
+    {
+        $_FILES['file'] = array(
+            "name" => "real-image.jpg",
+            "tmp_name" => $this->directory . 'real-image.jpg',
+            "size" => 12,
+            "error" => 0
+        );
+
+        $file = new File($_FILES['file']['tmp_name']);
+
+        $config = array(
+            'height' => 300
+        );
+
+        $this->assertTrue(
+            $this->createValidator($config)
+                ->validate($file, $_FILES['file']['size'])
+        );
+
+        $config = array(
+            'height' => 305
+        );
+
+        $this->assertFalse(
+            $this->createValidator($config)
+                ->validate($file, $_FILES['file']['size'])
+        );
+    }
+
+    public function testValidatorWorksWithTheMinimumHeightConfig()
+    {
+        $_FILES['file'] = array(
+            "name" => "real-image.jpg",
+            "tmp_name" => $this->directory . 'real-image.jpg',
+            "size" => 12,
+            "error" => 0
+        );
+
+        $file = new File($_FILES['file']['tmp_name']);
+
+        $config = array(
+            'min_height' => 200
+        );
+
+        $this->assertTrue(
+            $this->createValidator($config)
+                ->validate($file, $_FILES['file']['size'])
+        );
+
+        $config = array(
+            'min_height' => 301
+        );
+
+        $this->assertFalse(
+            $this->createValidator($config)
+                ->validate($file, $_FILES['file']['size'])
+        );
+    }
+
+    public function testValidatorWorksWithTheMaximumHeightConfig()
+    {
+        $_FILES['file'] = array(
+            "name" => "real-image.jpg",
+            "tmp_name" => $this->directory . 'real-image.jpg',
+            "size" => 12,
+            "error" => 0
+        );
+
+        $file = new File($_FILES['file']['tmp_name']);
+
+        $config = array(
+            'max_height' => 400
+        );
+
+        $this->assertTrue(
+            $this->createValidator($config)
+                ->validate($file, $_FILES['file']['size'])
+        );
+
+        $config = array(
+            'max_height' => 209
+        );
+
+        $this->assertFalse(
+            $this->createValidator($config)
+                ->validate($file, $_FILES['file']['size'])
+        );
+    }
+
+    public function testValidatorWorksAsExpectedWithAllConfigOption()
+    {
+        $_FILES['file'] = array(
+            "name" => "real-image.jpg",
+            "tmp_name" => $this->directory . 'real-image.jpg',
+            "size" => 12,
+            "error" => 0
+        );
+
+        $file = new File($_FILES['file']['tmp_name']);
+
+        $config = array(
+            'width' => 300,
+            'height' => 300,
+            'max_width' => 310,
+            'max_height' => 350
+        );
+
+        $this->assertTrue(
+            $this->createValidator($config)
+                ->validate($file, $_FILES['file']['size'])
+        );
+    }
+
+    public function testSetErrorMessages()
+    {
+
+        $_FILES['file'] = array(
+            "name" => "real-image.jpg",
+            "tmp_name" => $this->directory . 'real-image.jpg',
+            "size" => 12,
+            "error" => 0
+        );
+
+        $file = new File($_FILES['file']['tmp_name']);
+
+        $config = array(
+            'width' => 301,
+            'height' => 301
+        );
+
+        $validator = $this->createValidator($config);
+
+        $validator->setErrorMessages(array(
+            DimensionValidator::HEIGHT => "Height too large"
+        ));
+
+        $validator->validate($file, $_FILES['file']['size']);
+
+        $this->assertEquals(
+            'Height too large',
+            $file->error
+        );
+    }
+
+    protected function setUp()
+    {
+        $this->directory = __DIR__ . '/../../fixtures/';
+    }
+}


### PR DESCRIPTION
This PR intoduces a new validator, `DimensionValidator`. With this you can validate files by their width and size.

> This only works for images. If the uploaded file isn't an image, the validation would not pass.

```php

$config = [
  'width' => '260',
  'height' => '400'
]; //can also use min_width, max_width, min_height and max_height.

$validator = new DimensionValidator($config); //you should check your namespace imports

$fileUpload->addValidator($validator);

```
