### PR TITLE
improved slugify function to support more characters

### DIFF
--- a/src/FileUpload/FileNameGenerator/Slug.php
+++ b/src/FileUpload/FileNameGenerator/Slug.php
@@ -87,26 +87,124 @@ class Slug implements FileNameGenerator {
 		return $this->slugify( $fileNameExploded ) . "." . $extension;
 	}
 
+
 	/**
-	 * @param $text
+	 * Create a web friendly URL slug from a string.
 	 *
-	 * @return mixed|string
+	 * Although supported, transliteration is discouraged because
+	 *     1) most web browsers support UTF-8 characters in URLs
+	 *     2) transliteration causes a loss of information
+	 *
+	 * @author Sean Murphy <sean@iamseanmurphy.com>
+	 * @copyright Copyright 2012 Sean Murphy. All rights reserved.
+	 * @license http://creativecommons.org/publicdomain/zero/1.0/
+	 *
+	 * @param string $str
+	 * @param array $options
+	 * @return string
 	 */
-	private function slugify( $text ) {
-		// replace non letter or digits by -
-		$text = preg_replace( '~[^\\pL\d]+~u', '-', $text );
-		// trim
-		$text = trim( $text, '-' );
-		// transliterate
-		$text = iconv( 'utf-8', 'us-ascii//TRANSLIT', $text );
-		// lowercase
-		$text = strtolower( $text );
-		// remove unwanted characters
-		$text = preg_replace( '~[^-\w]+~', '', $text );
-		if ( empty( $text ) ) {
-			return 'n-a';
+	function slugify($str, $options = array()) {
+		// Make sure string is in UTF-8 and strip invalid UTF-8 characters
+		$str = mb_convert_encoding((string)$str, 'UTF-8', mb_list_encodings());
+
+		$defaults = array(
+			'delimiter' => '-',
+			'limit' => null,
+			'lowercase' => true,
+			'replacements' => array(),
+			'transliterate' => false,
+		);
+
+		// Merge options
+		$options = array_merge($defaults, $options);
+
+		$char_map = array(
+			// Latin
+			'À' => 'A', 'Á' => 'A', 'Â' => 'A', 'Ã' => 'A', 'Ä' => 'A', 'Å' => 'A', 'Æ' => 'AE', 'Ç' => 'C',
+			'È' => 'E', 'É' => 'E', 'Ê' => 'E', 'Ë' => 'E', 'Ì' => 'I', 'Í' => 'I', 'Î' => 'I', 'Ï' => 'I',
+			'Ð' => 'D', 'Ñ' => 'N', 'Ò' => 'O', 'Ó' => 'O', 'Ô' => 'O', 'Õ' => 'O', 'Ö' => 'O', 'Ő' => 'O',
+			'Ø' => 'O', 'Ù' => 'U', 'Ú' => 'U', 'Û' => 'U', 'Ü' => 'U', 'Ű' => 'U', 'Ý' => 'Y', 'Þ' => 'TH',
+			'ß' => 'ss',
+			'à' => 'a', 'á' => 'a', 'â' => 'a', 'ã' => 'a', 'ä' => 'a', 'å' => 'a', 'æ' => 'ae', 'ç' => 'c',
+			'è' => 'e', 'é' => 'e', 'ê' => 'e', 'ë' => 'e', 'ì' => 'i', 'í' => 'i', 'î' => 'i', 'ï' => 'i',
+			'ð' => 'd', 'ñ' => 'n', 'ò' => 'o', 'ó' => 'o', 'ô' => 'o', 'õ' => 'o', 'ö' => 'o', 'ő' => 'o',
+			'ø' => 'o', 'ù' => 'u', 'ú' => 'u', 'û' => 'u', 'ü' => 'u', 'ű' => 'u', 'ý' => 'y', 'þ' => 'th',
+			'ÿ' => 'y',
+
+			// Latin symbols
+			'©' => '(c)',
+
+			// Greek
+			'Α' => 'A', 'Β' => 'B', 'Γ' => 'G', 'Δ' => 'D', 'Ε' => 'E', 'Ζ' => 'Z', 'Η' => 'H', 'Θ' => '8',
+			'Ι' => 'I', 'Κ' => 'K', 'Λ' => 'L', 'Μ' => 'M', 'Ν' => 'N', 'Ξ' => '3', 'Ο' => 'O', 'Π' => 'P',
+			'Ρ' => 'R', 'Σ' => 'S', 'Τ' => 'T', 'Υ' => 'Y', 'Φ' => 'F', 'Χ' => 'X', 'Ψ' => 'PS', 'Ω' => 'W',
+			'Ά' => 'A', 'Έ' => 'E', 'Ί' => 'I', 'Ό' => 'O', 'Ύ' => 'Y', 'Ή' => 'H', 'Ώ' => 'W', 'Ϊ' => 'I',
+			'Ϋ' => 'Y',
+			'α' => 'a', 'β' => 'b', 'γ' => 'g', 'δ' => 'd', 'ε' => 'e', 'ζ' => 'z', 'η' => 'h', 'θ' => '8',
+			'ι' => 'i', 'κ' => 'k', 'λ' => 'l', 'μ' => 'm', 'ν' => 'n', 'ξ' => '3', 'ο' => 'o', 'π' => 'p',
+			'ρ' => 'r', 'σ' => 's', 'τ' => 't', 'υ' => 'y', 'φ' => 'f', 'χ' => 'x', 'ψ' => 'ps', 'ω' => 'w',
+			'ά' => 'a', 'έ' => 'e', 'ί' => 'i', 'ό' => 'o', 'ύ' => 'y', 'ή' => 'h', 'ώ' => 'w', 'ς' => 's',
+			'ϊ' => 'i', 'ΰ' => 'y', 'ϋ' => 'y', 'ΐ' => 'i',
+
+			// Turkish
+			'Ş' => 'S', 'İ' => 'I', 'Ç' => 'C', 'Ü' => 'U', 'Ö' => 'O', 'Ğ' => 'G',
+			'ş' => 's', 'ı' => 'i', 'ç' => 'c', 'ü' => 'u', 'ö' => 'o', 'ğ' => 'g',
+
+			// Russian
+			'А' => 'A', 'Б' => 'B', 'В' => 'V', 'Г' => 'G', 'Д' => 'D', 'Е' => 'E', 'Ё' => 'Yo', 'Ж' => 'Zh',
+			'З' => 'Z', 'И' => 'I', 'Й' => 'J', 'К' => 'K', 'Л' => 'L', 'М' => 'M', 'Н' => 'N', 'О' => 'O',
+			'П' => 'P', 'Р' => 'R', 'С' => 'S', 'Т' => 'T', 'У' => 'U', 'Ф' => 'F', 'Х' => 'H', 'Ц' => 'C',
+			'Ч' => 'Ch', 'Ш' => 'Sh', 'Щ' => 'Sh', 'Ъ' => '', 'Ы' => 'Y', 'Ь' => '', 'Э' => 'E', 'Ю' => 'Yu',
+			'Я' => 'Ya',
+			'а' => 'a', 'б' => 'b', 'в' => 'v', 'г' => 'g', 'д' => 'd', 'е' => 'e', 'ё' => 'yo', 'ж' => 'zh',
+			'з' => 'z', 'и' => 'i', 'й' => 'j', 'к' => 'k', 'л' => 'l', 'м' => 'm', 'н' => 'n', 'о' => 'o',
+			'п' => 'p', 'р' => 'r', 'с' => 's', 'т' => 't', 'у' => 'u', 'ф' => 'f', 'х' => 'h', 'ц' => 'c',
+			'ч' => 'ch', 'ш' => 'sh', 'щ' => 'sh', 'ъ' => '', 'ы' => 'y', 'ь' => '', 'э' => 'e', 'ю' => 'yu',
+			'я' => 'ya',
+
+			// Ukrainian
+			'Є' => 'Ye', 'І' => 'I', 'Ї' => 'Yi', 'Ґ' => 'G',
+			'є' => 'ye', 'і' => 'i', 'ї' => 'yi', 'ґ' => 'g',
+
+			// Czech
+			'Č' => 'C', 'Ď' => 'D', 'Ě' => 'E', 'Ň' => 'N', 'Ř' => 'R', 'Š' => 'S', 'Ť' => 'T', 'Ů' => 'U',
+			'Ž' => 'Z',
+			'č' => 'c', 'ď' => 'd', 'ě' => 'e', 'ň' => 'n', 'ř' => 'r', 'š' => 's', 'ť' => 't', 'ů' => 'u',
+			'ž' => 'z',
+
+			// Polish
+			'Ą' => 'A', 'Ć' => 'C', 'Ę' => 'e', 'Ł' => 'L', 'Ń' => 'N', 'Ó' => 'o', 'Ś' => 'S', 'Ź' => 'Z',
+			'Ż' => 'Z',
+			'ą' => 'a', 'ć' => 'c', 'ę' => 'e', 'ł' => 'l', 'ń' => 'n', 'ó' => 'o', 'ś' => 's', 'ź' => 'z',
+			'ż' => 'z',
+
+			// Latvian
+			'Ā' => 'A', 'Č' => 'C', 'Ē' => 'E', 'Ģ' => 'G', 'Ī' => 'i', 'Ķ' => 'k', 'Ļ' => 'L', 'Ņ' => 'N',
+			'Š' => 'S', 'Ū' => 'u', 'Ž' => 'Z',
+			'ā' => 'a', 'č' => 'c', 'ē' => 'e', 'ģ' => 'g', 'ī' => 'i', 'ķ' => 'k', 'ļ' => 'l', 'ņ' => 'n',
+			'š' => 's', 'ū' => 'u', 'ž' => 'z'
+		);
+
+		// Make custom replacements
+		$str = preg_replace(array_keys($options['replacements']), $options['replacements'], $str);
+
+		// Transliterate characters to ASCII
+		if ($options['transliterate']) {
+			$str = str_replace(array_keys($char_map), $char_map, $str);
 		}
 
-		return $text;
+		// Replace non-alphanumeric characters with our delimiter
+		$str = preg_replace('/[^\p{L}\p{Nd}]+/u', $options['delimiter'], $str);
+
+		// Remove duplicate delimiters
+		$str = preg_replace('/(' . preg_quote($options['delimiter'], '/') . '){2,}/', '$1', $str);
+
+		// Truncate slug to max. characters
+		$str = mb_substr($str, 0, ($options['limit'] ? $options['limit'] : mb_strlen($str, 'UTF-8')), 'UTF-8');
+
+		// Remove delimiter from ends
+		$str = trim($str, $options['delimiter']);
+
+		return $options['lowercase'] ? mb_strtolower($str, 'UTF-8') : $str;
 	}
 }

--- a/src/FileUpload/FileNameGenerator/Slug.php
+++ b/src/FileUpload/FileNameGenerator/Slug.php
@@ -30,12 +30,14 @@ class Slug implements FileNameGenerator
 
     /**
      * Get file_name
-     * @param  string       $source_name
-     * @param  string       $type
-     * @param  string       $tmp_name
-     * @param  integer      $index
-     * @param  string       $content_range
-     * @param  FileUpload   $upload
+     *
+     * @param  string $source_name
+     * @param  string $type
+     * @param  string $tmp_name
+     * @param  integer $index
+     * @param  string $content_range
+     * @param  FileUpload $upload
+     *
      * @return string
      */
     public function getFileName($source_name, $type, $tmp_name, $index, $content_range, FileUpload $upload)
@@ -51,10 +53,12 @@ class Slug implements FileNameGenerator
 
     /**
      * Get unique but consistent name
-     * @param  string  $name
-     * @param  string  $type
+     *
+     * @param  string $name
+     * @param  string $type
      * @param  integer $index
-     * @param  array   $content_range
+     * @param  array $content_range
+     *
      * @return string
      */
     protected function getUniqueFilename($name, $type, $index, $content_range)
@@ -76,137 +80,373 @@ class Slug implements FileNameGenerator
         return $name;
     }
 
-	/**
-	 * @param string $name
-	 *
-	 * @return string
-	 */
-	public function getSluggedFileName( $name ) {
-		$fileNameExploded = explode( ".", $name );
-		$extension        = array_pop( $fileNameExploded );
-		$fileNameExploded = implode( ".", $fileNameExploded );
+    /**
+     * @param string $name
+     *
+     * @return string
+     */
+    public function getSluggedFileName($name)
+    {
+        $fileNameExploded = explode(".", $name);
+        $extension        = array_pop($fileNameExploded);
+        $fileNameExploded = implode(".", $fileNameExploded);
 
-		return $this->slugify( $fileNameExploded ) . "." . $extension;
-	}
+        return $this->slugify($fileNameExploded) . "." . $extension;
+    }
 
 
-	/**
-	 * Create a web friendly URL slug from a string.
-	 *
-	 * Although supported, transliteration is discouraged because
-	 *     1) most web browsers support UTF-8 characters in URLs
-	 *     2) transliteration causes a loss of information
-	 *
-	 * @author Sean Murphy <sean@iamseanmurphy.com>
-	 * @copyright Copyright 2012 Sean Murphy. All rights reserved.
-	 * @license http://creativecommons.org/publicdomain/zero/1.0/
-	 *
-	 * @param string $str
-	 * @param array $options
-	 * @return string
-	 */
-	function slugify($str, $options = array()) {
-		// Make sure string is in UTF-8 and strip invalid UTF-8 characters
-		$str = mb_convert_encoding((string)$str, 'UTF-8', mb_list_encodings());
+    /**
+     * Create a web friendly URL slug from a string.
+     *
+     * Although supported, transliteration is discouraged because
+     *     1) most web browsers support UTF-8 characters in URLs
+     *     2) transliteration causes a loss of information
+     *
+     * @author Sean Murphy <sean@iamseanmurphy.com>
+     * @copyright Copyright 2012 Sean Murphy. All rights reserved.
+     * @license http://creativecommons.org/publicdomain/zero/1.0/
+     *
+     * @param string $str
+     * @param array $options
+     *
+     * @return string
+     */
+    function slugify($str, $options = array())
+    {
+        // Make sure string is in UTF-8 and strip invalid UTF-8 characters
+        $str = mb_convert_encoding((string)$str, 'UTF-8', mb_list_encodings());
 
-		$defaults = array(
-			'delimiter' => '-',
-			'limit' => null,
-			'lowercase' => true,
-			'replacements' => array(),
-			'transliterate' => false,
-		);
+        $defaults = array(
+            'delimiter'     => '-',
+            'limit'         => null,
+            'lowercase'     => true,
+            'replacements'  => array(),
+            'transliterate' => false,
+        );
 
-		// Merge options
-		$options = array_merge($defaults, $options);
+        // Merge options
+        $options = array_merge($defaults, $options);
 
-		$char_map = array(
-			// Latin
-			'À' => 'A', 'Á' => 'A', 'Â' => 'A', 'Ã' => 'A', 'Ä' => 'A', 'Å' => 'A', 'Æ' => 'AE', 'Ç' => 'C',
-			'È' => 'E', 'É' => 'E', 'Ê' => 'E', 'Ë' => 'E', 'Ì' => 'I', 'Í' => 'I', 'Î' => 'I', 'Ï' => 'I',
-			'Ð' => 'D', 'Ñ' => 'N', 'Ò' => 'O', 'Ó' => 'O', 'Ô' => 'O', 'Õ' => 'O', 'Ö' => 'O', 'Ő' => 'O',
-			'Ø' => 'O', 'Ù' => 'U', 'Ú' => 'U', 'Û' => 'U', 'Ü' => 'U', 'Ű' => 'U', 'Ý' => 'Y', 'Þ' => 'TH',
-			'ß' => 'ss',
-			'à' => 'a', 'á' => 'a', 'â' => 'a', 'ã' => 'a', 'ä' => 'a', 'å' => 'a', 'æ' => 'ae', 'ç' => 'c',
-			'è' => 'e', 'é' => 'e', 'ê' => 'e', 'ë' => 'e', 'ì' => 'i', 'í' => 'i', 'î' => 'i', 'ï' => 'i',
-			'ð' => 'd', 'ñ' => 'n', 'ò' => 'o', 'ó' => 'o', 'ô' => 'o', 'õ' => 'o', 'ö' => 'o', 'ő' => 'o',
-			'ø' => 'o', 'ù' => 'u', 'ú' => 'u', 'û' => 'u', 'ü' => 'u', 'ű' => 'u', 'ý' => 'y', 'þ' => 'th',
-			'ÿ' => 'y',
+        $char_map = array(
+            // Latin
+            'À' => 'A',
+            'Á' => 'A',
+            'Â' => 'A',
+            'Ã' => 'A',
+            'Ä' => 'A',
+            'Å' => 'A',
+            'Æ' => 'AE',
+            'Ç' => 'C',
+            'È' => 'E',
+            'É' => 'E',
+            'Ê' => 'E',
+            'Ë' => 'E',
+            'Ì' => 'I',
+            'Í' => 'I',
+            'Î' => 'I',
+            'Ï' => 'I',
+            'Ð' => 'D',
+            'Ñ' => 'N',
+            'Ò' => 'O',
+            'Ó' => 'O',
+            'Ô' => 'O',
+            'Õ' => 'O',
+            'Ö' => 'O',
+            'Ő' => 'O',
+            'Ø' => 'O',
+            'Ù' => 'U',
+            'Ú' => 'U',
+            'Û' => 'U',
+            'Ü' => 'U',
+            'Ű' => 'U',
+            'Ý' => 'Y',
+            'Þ' => 'TH',
+            'ß' => 'ss',
+            'à' => 'a',
+            'á' => 'a',
+            'â' => 'a',
+            'ã' => 'a',
+            'ä' => 'a',
+            'å' => 'a',
+            'æ' => 'ae',
+            'ç' => 'c',
+            'è' => 'e',
+            'é' => 'e',
+            'ê' => 'e',
+            'ë' => 'e',
+            'ì' => 'i',
+            'í' => 'i',
+            'î' => 'i',
+            'ï' => 'i',
+            'ð' => 'd',
+            'ñ' => 'n',
+            'ò' => 'o',
+            'ó' => 'o',
+            'ô' => 'o',
+            'õ' => 'o',
+            'ö' => 'o',
+            'ő' => 'o',
+            'ø' => 'o',
+            'ù' => 'u',
+            'ú' => 'u',
+            'û' => 'u',
+            'ü' => 'u',
+            'ű' => 'u',
+            'ý' => 'y',
+            'þ' => 'th',
+            'ÿ' => 'y',
 
-			// Latin symbols
-			'©' => '(c)',
+            // Latin symbols
+            '©' => '(c)',
 
-			// Greek
-			'Α' => 'A', 'Β' => 'B', 'Γ' => 'G', 'Δ' => 'D', 'Ε' => 'E', 'Ζ' => 'Z', 'Η' => 'H', 'Θ' => '8',
-			'Ι' => 'I', 'Κ' => 'K', 'Λ' => 'L', 'Μ' => 'M', 'Ν' => 'N', 'Ξ' => '3', 'Ο' => 'O', 'Π' => 'P',
-			'Ρ' => 'R', 'Σ' => 'S', 'Τ' => 'T', 'Υ' => 'Y', 'Φ' => 'F', 'Χ' => 'X', 'Ψ' => 'PS', 'Ω' => 'W',
-			'Ά' => 'A', 'Έ' => 'E', 'Ί' => 'I', 'Ό' => 'O', 'Ύ' => 'Y', 'Ή' => 'H', 'Ώ' => 'W', 'Ϊ' => 'I',
-			'Ϋ' => 'Y',
-			'α' => 'a', 'β' => 'b', 'γ' => 'g', 'δ' => 'd', 'ε' => 'e', 'ζ' => 'z', 'η' => 'h', 'θ' => '8',
-			'ι' => 'i', 'κ' => 'k', 'λ' => 'l', 'μ' => 'm', 'ν' => 'n', 'ξ' => '3', 'ο' => 'o', 'π' => 'p',
-			'ρ' => 'r', 'σ' => 's', 'τ' => 't', 'υ' => 'y', 'φ' => 'f', 'χ' => 'x', 'ψ' => 'ps', 'ω' => 'w',
-			'ά' => 'a', 'έ' => 'e', 'ί' => 'i', 'ό' => 'o', 'ύ' => 'y', 'ή' => 'h', 'ώ' => 'w', 'ς' => 's',
-			'ϊ' => 'i', 'ΰ' => 'y', 'ϋ' => 'y', 'ΐ' => 'i',
+            // Greek
+            'Α' => 'A',
+            'Β' => 'B',
+            'Γ' => 'G',
+            'Δ' => 'D',
+            'Ε' => 'E',
+            'Ζ' => 'Z',
+            'Η' => 'H',
+            'Θ' => '8',
+            'Ι' => 'I',
+            'Κ' => 'K',
+            'Λ' => 'L',
+            'Μ' => 'M',
+            'Ν' => 'N',
+            'Ξ' => '3',
+            'Ο' => 'O',
+            'Π' => 'P',
+            'Ρ' => 'R',
+            'Σ' => 'S',
+            'Τ' => 'T',
+            'Υ' => 'Y',
+            'Φ' => 'F',
+            'Χ' => 'X',
+            'Ψ' => 'PS',
+            'Ω' => 'W',
+            'Ά' => 'A',
+            'Έ' => 'E',
+            'Ί' => 'I',
+            'Ό' => 'O',
+            'Ύ' => 'Y',
+            'Ή' => 'H',
+            'Ώ' => 'W',
+            'Ϊ' => 'I',
+            'Ϋ' => 'Y',
+            'α' => 'a',
+            'β' => 'b',
+            'γ' => 'g',
+            'δ' => 'd',
+            'ε' => 'e',
+            'ζ' => 'z',
+            'η' => 'h',
+            'θ' => '8',
+            'ι' => 'i',
+            'κ' => 'k',
+            'λ' => 'l',
+            'μ' => 'm',
+            'ν' => 'n',
+            'ξ' => '3',
+            'ο' => 'o',
+            'π' => 'p',
+            'ρ' => 'r',
+            'σ' => 's',
+            'τ' => 't',
+            'υ' => 'y',
+            'φ' => 'f',
+            'χ' => 'x',
+            'ψ' => 'ps',
+            'ω' => 'w',
+            'ά' => 'a',
+            'έ' => 'e',
+            'ί' => 'i',
+            'ό' => 'o',
+            'ύ' => 'y',
+            'ή' => 'h',
+            'ώ' => 'w',
+            'ς' => 's',
+            'ϊ' => 'i',
+            'ΰ' => 'y',
+            'ϋ' => 'y',
+            'ΐ' => 'i',
 
-			// Turkish
-			'Ş' => 'S', 'İ' => 'I', 'Ç' => 'C', 'Ü' => 'U', 'Ö' => 'O', 'Ğ' => 'G',
-			'ş' => 's', 'ı' => 'i', 'ç' => 'c', 'ü' => 'u', 'ö' => 'o', 'ğ' => 'g',
+            // Turkish
+            'Ş' => 'S',
+            'İ' => 'I',
+            'Ç' => 'C',
+            'Ü' => 'U',
+            'Ö' => 'O',
+            'Ğ' => 'G',
+            'ş' => 's',
+            'ı' => 'i',
+            'ç' => 'c',
+            'ü' => 'u',
+            'ö' => 'o',
+            'ğ' => 'g',
 
-			// Russian
-			'А' => 'A', 'Б' => 'B', 'В' => 'V', 'Г' => 'G', 'Д' => 'D', 'Е' => 'E', 'Ё' => 'Yo', 'Ж' => 'Zh',
-			'З' => 'Z', 'И' => 'I', 'Й' => 'J', 'К' => 'K', 'Л' => 'L', 'М' => 'M', 'Н' => 'N', 'О' => 'O',
-			'П' => 'P', 'Р' => 'R', 'С' => 'S', 'Т' => 'T', 'У' => 'U', 'Ф' => 'F', 'Х' => 'H', 'Ц' => 'C',
-			'Ч' => 'Ch', 'Ш' => 'Sh', 'Щ' => 'Sh', 'Ъ' => '', 'Ы' => 'Y', 'Ь' => '', 'Э' => 'E', 'Ю' => 'Yu',
-			'Я' => 'Ya',
-			'а' => 'a', 'б' => 'b', 'в' => 'v', 'г' => 'g', 'д' => 'd', 'е' => 'e', 'ё' => 'yo', 'ж' => 'zh',
-			'з' => 'z', 'и' => 'i', 'й' => 'j', 'к' => 'k', 'л' => 'l', 'м' => 'm', 'н' => 'n', 'о' => 'o',
-			'п' => 'p', 'р' => 'r', 'с' => 's', 'т' => 't', 'у' => 'u', 'ф' => 'f', 'х' => 'h', 'ц' => 'c',
-			'ч' => 'ch', 'ш' => 'sh', 'щ' => 'sh', 'ъ' => '', 'ы' => 'y', 'ь' => '', 'э' => 'e', 'ю' => 'yu',
-			'я' => 'ya',
+            // Russian
+            'А' => 'A',
+            'Б' => 'B',
+            'В' => 'V',
+            'Г' => 'G',
+            'Д' => 'D',
+            'Е' => 'E',
+            'Ё' => 'Yo',
+            'Ж' => 'Zh',
+            'З' => 'Z',
+            'И' => 'I',
+            'Й' => 'J',
+            'К' => 'K',
+            'Л' => 'L',
+            'М' => 'M',
+            'Н' => 'N',
+            'О' => 'O',
+            'П' => 'P',
+            'Р' => 'R',
+            'С' => 'S',
+            'Т' => 'T',
+            'У' => 'U',
+            'Ф' => 'F',
+            'Х' => 'H',
+            'Ц' => 'C',
+            'Ч' => 'Ch',
+            'Ш' => 'Sh',
+            'Щ' => 'Sh',
+            'Ъ' => '',
+            'Ы' => 'Y',
+            'Ь' => '',
+            'Э' => 'E',
+            'Ю' => 'Yu',
+            'Я' => 'Ya',
+            'а' => 'a',
+            'б' => 'b',
+            'в' => 'v',
+            'г' => 'g',
+            'д' => 'd',
+            'е' => 'e',
+            'ё' => 'yo',
+            'ж' => 'zh',
+            'з' => 'z',
+            'и' => 'i',
+            'й' => 'j',
+            'к' => 'k',
+            'л' => 'l',
+            'м' => 'm',
+            'н' => 'n',
+            'о' => 'o',
+            'п' => 'p',
+            'р' => 'r',
+            'с' => 's',
+            'т' => 't',
+            'у' => 'u',
+            'ф' => 'f',
+            'х' => 'h',
+            'ц' => 'c',
+            'ч' => 'ch',
+            'ш' => 'sh',
+            'щ' => 'sh',
+            'ъ' => '',
+            'ы' => 'y',
+            'ь' => '',
+            'э' => 'e',
+            'ю' => 'yu',
+            'я' => 'ya',
 
-			// Ukrainian
-			'Є' => 'Ye', 'І' => 'I', 'Ї' => 'Yi', 'Ґ' => 'G',
-			'є' => 'ye', 'і' => 'i', 'ї' => 'yi', 'ґ' => 'g',
+            // Ukrainian
+            'Є' => 'Ye',
+            'І' => 'I',
+            'Ї' => 'Yi',
+            'Ґ' => 'G',
+            'є' => 'ye',
+            'і' => 'i',
+            'ї' => 'yi',
+            'ґ' => 'g',
 
-			// Czech
-			'Č' => 'C', 'Ď' => 'D', 'Ě' => 'E', 'Ň' => 'N', 'Ř' => 'R', 'Š' => 'S', 'Ť' => 'T', 'Ů' => 'U',
-			'Ž' => 'Z',
-			'č' => 'c', 'ď' => 'd', 'ě' => 'e', 'ň' => 'n', 'ř' => 'r', 'š' => 's', 'ť' => 't', 'ů' => 'u',
-			'ž' => 'z',
+            // Czech
+            'Č' => 'C',
+            'Ď' => 'D',
+            'Ě' => 'E',
+            'Ň' => 'N',
+            'Ř' => 'R',
+            'Š' => 'S',
+            'Ť' => 'T',
+            'Ů' => 'U',
+            'Ž' => 'Z',
+            'č' => 'c',
+            'ď' => 'd',
+            'ě' => 'e',
+            'ň' => 'n',
+            'ř' => 'r',
+            'š' => 's',
+            'ť' => 't',
+            'ů' => 'u',
+            'ž' => 'z',
 
-			// Polish
-			'Ą' => 'A', 'Ć' => 'C', 'Ę' => 'e', 'Ł' => 'L', 'Ń' => 'N', 'Ó' => 'o', 'Ś' => 'S', 'Ź' => 'Z',
-			'Ż' => 'Z',
-			'ą' => 'a', 'ć' => 'c', 'ę' => 'e', 'ł' => 'l', 'ń' => 'n', 'ó' => 'o', 'ś' => 's', 'ź' => 'z',
-			'ż' => 'z',
+            // Polish
+            'Ą' => 'A',
+            'Ć' => 'C',
+            'Ę' => 'e',
+            'Ł' => 'L',
+            'Ń' => 'N',
+            'Ó' => 'o',
+            'Ś' => 'S',
+            'Ź' => 'Z',
+            'Ż' => 'Z',
+            'ą' => 'a',
+            'ć' => 'c',
+            'ę' => 'e',
+            'ł' => 'l',
+            'ń' => 'n',
+            'ó' => 'o',
+            'ś' => 's',
+            'ź' => 'z',
+            'ż' => 'z',
 
-			// Latvian
-			'Ā' => 'A', 'Č' => 'C', 'Ē' => 'E', 'Ģ' => 'G', 'Ī' => 'i', 'Ķ' => 'k', 'Ļ' => 'L', 'Ņ' => 'N',
-			'Š' => 'S', 'Ū' => 'u', 'Ž' => 'Z',
-			'ā' => 'a', 'č' => 'c', 'ē' => 'e', 'ģ' => 'g', 'ī' => 'i', 'ķ' => 'k', 'ļ' => 'l', 'ņ' => 'n',
-			'š' => 's', 'ū' => 'u', 'ž' => 'z'
-		);
+            // Latvian
+            'Ā' => 'A',
+            'Č' => 'C',
+            'Ē' => 'E',
+            'Ģ' => 'G',
+            'Ī' => 'i',
+            'Ķ' => 'k',
+            'Ļ' => 'L',
+            'Ņ' => 'N',
+            'Š' => 'S',
+            'Ū' => 'u',
+            'Ž' => 'Z',
+            'ā' => 'a',
+            'č' => 'c',
+            'ē' => 'e',
+            'ģ' => 'g',
+            'ī' => 'i',
+            'ķ' => 'k',
+            'ļ' => 'l',
+            'ņ' => 'n',
+            'š' => 's',
+            'ū' => 'u',
+            'ž' => 'z'
+        );
 
-		// Make custom replacements
-		$str = preg_replace(array_keys($options['replacements']), $options['replacements'], $str);
+        // Make custom replacements
+        $str = preg_replace(array_keys($options['replacements']), $options['replacements'], $str);
 
-		// Transliterate characters to ASCII
-		if ($options['transliterate']) {
-			$str = str_replace(array_keys($char_map), $char_map, $str);
-		}
+        // Transliterate characters to ASCII
+        if ($options['transliterate']) {
+            $str = str_replace(array_keys($char_map), $char_map, $str);
+        }
 
-		// Replace non-alphanumeric characters with our delimiter
-		$str = preg_replace('/[^\p{L}\p{Nd}]+/u', $options['delimiter'], $str);
+        // Replace non-alphanumeric characters with our delimiter
+        $str = preg_replace('/[^\p{L}\p{Nd}]+/u', $options['delimiter'], $str);
 
-		// Remove duplicate delimiters
-		$str = preg_replace('/(' . preg_quote($options['delimiter'], '/') . '){2,}/', '$1', $str);
+        // Remove duplicate delimiters
+        $str = preg_replace('/(' . preg_quote($options['delimiter'], '/') . '){2,}/', '$1', $str);
 
-		// Truncate slug to max. characters
-		$str = mb_substr($str, 0, ($options['limit'] ? $options['limit'] : mb_strlen($str, 'UTF-8')), 'UTF-8');
+        // Truncate slug to max. characters
+        $str = mb_substr($str, 0, ($options['limit'] ? $options['limit'] : mb_strlen($str, 'UTF-8')), 'UTF-8');
 
-		// Remove delimiter from ends
-		$str = trim($str, $options['delimiter']);
+        // Remove delimiter from ends
+        $str = trim($str, $options['delimiter']);
 
-		return $options['lowercase'] ? mb_strtolower($str, 'UTF-8') : $str;
-	}
+        return $options['lowercase'] ? mb_strtolower($str, 'UTF-8') : $str;
+    }
 }

--- a/src/FileUpload/FileNameGenerator/Slug.php
+++ b/src/FileUpload/FileNameGenerator/Slug.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: decola
+ * Date: 11.07.14
+ * Time: 14:00
+ */
+
+namespace FileUpload\FileNameGenerator;
+
+use FileUpload\FileSystem\FileSystem;
+use FileUpload\PathResolver\PathResolver;
+use FileUpload\FileUpload;
+use FileUpload\Util;
+
+class Slug implements FileNameGenerator {
+
+    /**
+     * Pathresolver
+     * @var PathResolver
+     */
+    private $pathresolver;
+
+    /**
+     * Filesystem
+     * @var FileSystem
+     */
+    private $filesystem;
+
+    /**
+     * Get file_name
+     * @param  string       $source_name
+     * @param  string       $type
+     * @param  string       $tmp_name
+     * @param  integer      $index
+     * @param  string       $content_range
+     * @param  FileUpload   $upload
+     * @return string
+     */
+    public function getFileName($source_name, $type, $tmp_name, $index, $content_range, FileUpload $upload)
+    {
+	    $this->filesystem   = $upload->getFileSystem();
+	    $this->pathresolver = $upload->getPathResolver();
+
+	    $source_name    = $this->getSluggedFileName( $source_name );
+	    $uniqueFileName = $this->getUniqueFilename( $source_name, $type, $index, $content_range );
+
+	    return $this->getSluggedFileName( $uniqueFileName );
+    }
+
+    /**
+     * Get unique but consistent name
+     * @param  string  $name
+     * @param  string  $type
+     * @param  integer $index
+     * @param  array   $content_range
+     * @return string
+     */
+    protected function getUniqueFilename($name, $type, $index, $content_range) {
+	    while ( $this->filesystem->isDir( $this->pathresolver->getUploadPath( $this->getSluggedFileName( $name ) ) ) ) {
+		    $name = $this->pathresolver->upcountName( $name );
+	    }
+
+	    $uploaded_bytes = Util::fixIntegerOverflow( intval( $content_range[1] ) );
+
+	    while ( $this->filesystem->isFile( $this->pathresolver->getUploadPath( $this->getSluggedFileName( $name ) ) ) ) {
+		    if ( $uploaded_bytes == $this->filesystem->getFilesize( $this->pathresolver->getUploadPath( $this->getSluggedFileName( $name ) ) ) ) {
+			    break;
+		    }
+
+		    $name = $this->pathresolver->upcountName( $name );
+	    }
+
+	    return $name;
+    }
+
+	/**
+	 * @param string $name
+	 *
+	 * @return string
+	 */
+	public function getSluggedFileName( $name ) {
+		$fileNameExploded = explode( ".", $name );
+		$extension        = array_pop( $fileNameExploded );
+		$fileNameExploded = implode( ".", $fileNameExploded );
+
+		return $this->slugify( $fileNameExploded ) . "." . $extension;
+	}
+
+	/**
+	 * @param $text
+	 *
+	 * @return mixed|string
+	 */
+	private function slugify( $text ) {
+		// replace non letter or digits by -
+		$text = preg_replace( '~[^\\pL\d]+~u', '-', $text );
+		// trim
+		$text = trim( $text, '-' );
+		// transliterate
+		$text = iconv( 'utf-8', 'us-ascii//TRANSLIT', $text );
+		// lowercase
+		$text = strtolower( $text );
+		// remove unwanted characters
+		$text = preg_replace( '~[^-\w]+~', '', $text );
+		if ( empty( $text ) ) {
+			return 'n-a';
+		}
+
+		return $text;
+	}
+}

--- a/tests/FileUpload/FileNameGenerator/SlugTest.php
+++ b/tests/FileUpload/FileNameGenerator/SlugTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace FileUpload\FileNameGenerator;
+
+use FileUpload\FileSystem\Mock;
+use FileUpload\FileUpload;
+use FileUpload\PathResolver\Simple;
+use FileUpload\FileNameGenerator\Slug as SlugGenerator;
+
+class SlugTest extends \PHPUnit_Framework_TestCase
+{
+    protected $filesystem;
+
+    public function setUp()
+    {
+
+    }
+
+    public function testGenerator()
+    {
+
+        $generator = new SlugGenerator();
+        $playground_path = __DIR__ . '/../playground';
+
+        $filesystem = new Mock();
+        $resolver   = new Simple($playground_path . '/uploaded');
+
+        $server = array('CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321);
+        $file   = array('tmp_name' => $playground_path . '/real-image.jpg', 'name' => 'real-image.jpg', 'size' => 30321, 'type' => 'image/jpg', 'error' => 0);
+
+        $fileUpload = new FileUpload($file , $server , $generator);
+        $fileUpload->setPathResolver($resolver);
+        $fileUpload->setFileSystem($filesystem);
+
+        $filename = "Awesome Picture 2.jpg";
+        $expectedFilename = "awesome-picture-2.jpg";
+
+        $this->assertEquals($generator->getFileName($filename, "image/jpg", "asdf.jpg", 0, 100 ,$fileUpload), $expectedFilename);
+
+    }
+
+}

--- a/tests/FileUpload/FileNameGenerator/SlugTest.php
+++ b/tests/FileUpload/FileNameGenerator/SlugTest.php
@@ -19,7 +19,7 @@ class SlugTest extends \PHPUnit_Framework_TestCase
     public function testGenerator()
     {
 
-        $generator = new SlugGenerator();
+        $generator       = new SlugGenerator();
         $playground_path = __DIR__ . '/../playground';
 
         $filesystem = new Mock();
@@ -28,18 +28,18 @@ class SlugTest extends \PHPUnit_Framework_TestCase
         $server = array('CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321);
         $file   = array('tmp_name' => $playground_path . '/real-image.jpg', 'name' => 'real-image.jpg', 'size' => 30321, 'type' => 'image/jpg', 'error' => 0);
 
-        $fileUpload = new FileUpload($file , $server , $generator);
+        $fileUpload = new FileUpload($file, $server, $generator);
         $fileUpload->setPathResolver($resolver);
         $fileUpload->setFileSystem($filesystem);
 
-        $filename = "Awesome Picture 2.jpg";
+        $filename         = "Awesome Picture 2.jpg";
         $expectedFilename = "awesome-picture-2.jpg";
 
-        $this->assertEquals($generator->getFileName($filename, "image/jpg", "asdf.jpg", 0, 100 ,$fileUpload), $expectedFilename);
+        $this->assertEquals($generator->getFileName($filename, "image/jpg", "asdf.jpg", 0, 100, $fileUpload), $expectedFilename);
 
-        $filename = "Attività può più lunedì perchè.jpg";
+        $filename         = "Attività può più lunedì perchè.jpg";
         $expectedFilename = "attivita-puo-piu-lunedi-perche.jpg";
-        $this->assertEquals($generator->getFileName($filename, "image/jpg", "asdf.jpg", 0, 100 ,$fileUpload), $expectedFilename);
+        $this->assertEquals($generator->getFileName($filename, "image/jpg", "asdf.jpg", 0, 100, $fileUpload), $expectedFilename);
 
     }
 

--- a/tests/FileUpload/FileNameGenerator/SlugTest.php
+++ b/tests/FileUpload/FileNameGenerator/SlugTest.php
@@ -37,6 +37,10 @@ class SlugTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($generator->getFileName($filename, "image/jpg", "asdf.jpg", 0, 100 ,$fileUpload), $expectedFilename);
 
+        $filename = "Attività può più lunedì perchè.jpg";
+        $expectedFilename = "attivita-puo-piu-lunedi-perche.jpg";
+        $this->assertEquals($generator->getFileName($filename, "image/jpg", "asdf.jpg", 0, 100 ,$fileUpload), $expectedFilename);
+
     }
 
 }


### PR DESCRIPTION
The old one had an issue with some UTF-8 character, for example italian character à,ò,è,é,ì would not be converted to their "flattened" version (a,o,e,e,i) but instead they would get truncated. I think this is not always the inted behaviour so i replaced with another one found online. Credit goes to the creator of it (mentioned in comments). Licence is cc so it's fine i guess