### PR TITLE
Fix for issue #52

### DIFF
--- a/src/FileUpload/File.php
+++ b/src/FileUpload/File.php
@@ -36,7 +36,9 @@ class File extends \SplFileInfo
 
     protected function setMimeType($fileName)
     {
-        $this->mimeType = finfo_file(finfo_open(FILEINFO_MIME_TYPE), $fileName);
+        if (file_exists($fileName)) {
+            $this->mimeType = finfo_file(finfo_open(FILEINFO_MIME_TYPE), $fileName);
+        }
     }
 
     public function getMimeType()

--- a/src/FileUpload/FileUpload.php
+++ b/src/FileUpload/FileUpload.php
@@ -259,7 +259,10 @@ class FileUpload
                 );
             } else {
                 if ($upload && $upload['error'] != 0) {
-                    $file = $this->getFileContainer();
+                    // $this->fileContainer is empty at this point
+                    // $upload['tmp_name'] is also empty
+                    // So we create a File instance from $upload['name']
+                    $file = new File($upload['name']);
                     $file->error = $this->getMessage($upload['error']);
                     $file->errorCode = $upload['error'];
                     $this->files[] = $file;

--- a/src/FileUpload/FileUpload.php
+++ b/src/FileUpload/FileUpload.php
@@ -583,7 +583,7 @@ class FileUpload
             'x-content-type-options' => 'nosniff'
         );
 
-        if ($content_range && is_object($files[0]) && $files[0]->size) {
+        if ($content_range && is_object($files[0]) && isset($files[0]->size) && $files[0]->size) {
             $headers['range'] = '0-' . ($this->fixIntegerOverflow($files[0]->size) - 1);
         }
 


### PR DESCRIPTION
PR to fix the issue #52

- Fix an issue in `FileUpload::ProcessAll()` when aborting an upload, no tmp_name was defined and an empty fileContainer was used leading to an error message `Warning --> Creating default object from empty value FileUpload.php 263`
- Improvement: a `File` object can now reference a non-existing file without error (just like its SplFileInfo parent)
- Fix an issue in `FileUpload::getNewHeaders()` where the file's `size` attribute could be used without checking its existence.
