### PR TITLE
Require >= PHP 7

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,19 @@
+<?php
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__)
+    ->name('*.php')
+    ->ignoreDotFiles(true)
+    ->ignoreVCS(true)
+;
+
+return PhpCsFixer\Config::create()
+    ->setRules(array(
+        'binary_operator_spaces' => ['align_double_arrow' => false],
+        'array_syntax' => ['syntax' => 'short'],
+        'linebreak_after_opening_tag' => true,
+        'not_operator_with_successor_space' => true,
+        'ordered_imports' => true,
+        'phpdoc_order' => true,
+    ))
+    ->setFinder($finder)
+;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 before_script:
   - composer selfupdate

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,10 @@
       "FileUpload\\": "src/"
     }
   },
+  "require": {
+    "php": "~7.0"
+  },
   "require-dev": {
-    "phpunit/phpunit": "3.7.*"
+    "phpunit/phpunit": "^6.0"
   }
 }

--- a/src/FileUpload/File.php
+++ b/src/FileUpload/File.php
@@ -33,7 +33,7 @@ class File extends \SplFileInfo
      */
     public $completed = false;
 
-    public function __construct($fileName, $clientFileName='')
+    public function __construct($fileName, $clientFileName = '')
     {
         $this->setMimeType($fileName);
         $this->clientFileName = $clientFileName;
@@ -73,7 +73,7 @@ class File extends \SplFileInfo
     {
         return in_array(
             $this->mimeType,
-            array('image/gif', 'image/jpeg', 'image/pjpeg', 'image/png')
+            ['image/gif', 'image/jpeg', 'image/pjpeg', 'image/png']
         );
     }
 }

--- a/src/FileUpload/FileNameGenerator/Custom.php
+++ b/src/FileUpload/FileNameGenerator/Custom.php
@@ -22,7 +22,7 @@ class Custom implements FileNameGenerator
     public function getFileName($source_name, $type, $tmp_name, $index, $content_range, FileUpload $upload)
     {
 
-        if (is_string($this->generator) && !is_callable($this->generator)) {
+        if (is_string($this->generator) && ! is_callable($this->generator)) {
             return $this->generator;
         }
 

--- a/src/FileUpload/FileNameGenerator/Random.php
+++ b/src/FileUpload/FileNameGenerator/Random.php
@@ -3,8 +3,8 @@
 
 namespace FileUpload\FileNameGenerator;
 
-use FileUpload\Util;
 use FileUpload\FileUpload;
+use FileUpload\Util;
 
 class Random implements FileNameGenerator
 {

--- a/src/FileUpload/FileNameGenerator/Simple.php
+++ b/src/FileUpload/FileNameGenerator/Simple.php
@@ -9,8 +9,8 @@
 namespace FileUpload\FileNameGenerator;
 
 use FileUpload\FileSystem\FileSystem;
-use FileUpload\PathResolver\PathResolver;
 use FileUpload\FileUpload;
+use FileUpload\PathResolver\PathResolver;
 use FileUpload\Util;
 
 class Simple implements FileNameGenerator

--- a/src/FileUpload/FileNameGenerator/Slug.php
+++ b/src/FileUpload/FileNameGenerator/Slug.php
@@ -9,8 +9,8 @@
 namespace FileUpload\FileNameGenerator;
 
 use FileUpload\FileSystem\FileSystem;
-use FileUpload\PathResolver\PathResolver;
 use FileUpload\FileUpload;
+use FileUpload\PathResolver\PathResolver;
 use FileUpload\Util;
 
 class Slug implements FileNameGenerator
@@ -40,10 +40,10 @@ class Slug implements FileNameGenerator
      */
     public function getFileName($source_name, $type, $tmp_name, $index, $content_range, FileUpload $upload)
     {
-        $this->filesystem   = $upload->getFileSystem();
+        $this->filesystem = $upload->getFileSystem();
         $this->pathresolver = $upload->getPathResolver();
 
-        $source_name    = $this->getSluggedFileName($source_name);
+        $source_name = $this->getSluggedFileName($source_name);
         $uniqueFileName = $this->getUniqueFilename($source_name, $type, $index, $content_range);
 
         return $this->getSluggedFileName($uniqueFileName);
@@ -84,7 +84,7 @@ class Slug implements FileNameGenerator
     public function getSluggedFileName($name)
     {
         $fileNameExploded = explode(".", $name);
-        $extension        = array_pop($fileNameExploded);
+        $extension = array_pop($fileNameExploded);
         $fileNameExploded = implode(".", $fileNameExploded);
 
         return $this->slugify($fileNameExploded) . "." . $extension;

--- a/src/FileUpload/FileUpload.php
+++ b/src/FileUpload/FileUpload.php
@@ -59,17 +59,17 @@ class FileUpload
      * Validators to be run
      * @var array
      */
-    protected $validators = array();
+    protected $validators = [];
     /**
      * Callbacks to be run
      * @var array
      */
-    protected $callbacks = array();
+    protected $callbacks = [];
     /**
      * Default messages
      * @var array
      */
-    protected $messages = array(
+    protected $messages = [
         // PHP $_FILES-own
         UPLOAD_ERR_INI_SIZE => 'The uploaded file exceeds the upload_max_filesize directive in php.ini',
         UPLOAD_ERR_FORM_SIZE => 'The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the HTML form',
@@ -81,7 +81,7 @@ class FileUpload
 
         // Our own
         self::UPLOAD_ERR_PHP_SIZE => 'The upload file exceeds the post_max_size or the upload_max_filesize directives in php.ini',
-    );
+    ];
 
     /**
      * Construct this mother
@@ -104,7 +104,7 @@ class FileUpload
      */
     private function prepareMessages()
     {
-        $prepared = array();
+        $prepared = [];
 
         foreach ($this->messages as $key => $msg) {
             $prepared[(string)$key] = $msg;
@@ -217,16 +217,16 @@ class FileUpload
     {
         $content_range = $this->getContentRange();
         $size = $this->getSize();
-        $this->files = array();
+        $this->files = [];
         $upload = $this->upload;
 
         if ($this->logger) {
-            $this->logger->debug('Processing uploads', array(
+            $this->logger->debug('Processing uploads', [
                 'Content-range' => $content_range,
                 'Size' => $size,
                 'Upload array' => $upload,
                 'Server array' => $this->server,
-            ));
+            ]);
         }
 
         if ($upload && is_array($upload['tmp_name'])) {
@@ -247,7 +247,7 @@ class FileUpload
                 );
             }
         } else {
-            if ($upload && !empty($upload['tmp_name'])) {
+            if ($upload && ! empty($upload['tmp_name'])) {
                 $this->files[] = $this->process(
                     $upload['tmp_name'],
                     $upload['name'],
@@ -270,7 +270,7 @@ class FileUpload
             }
         }
 
-        return array($this->files, $this->getNewHeaders($this->files, $content_range));
+        return [$this->files, $this->getNewHeaders($this->files, $content_range)];
     }
 
     /**
@@ -337,20 +337,20 @@ class FileUpload
                 $file_size = $this->getFilesize($file_path, $append_file);
 
                 if ($this->logger) {
-                    $this->logger->debug('Processing ' . $file->name, array(
+                    $this->logger->debug('Processing ' . $file->name, [
                         'File path' => $file_path,
                         'File object' => $file,
                         'Append to file?' => $append_file,
                         'File exists?' => $this->filesystem->isFile($file_path),
                         'File size' => $file_size,
-                    ));
+                    ]);
                 }
 
                 if ($file->size == $file_size) {
                     // Yay, upload is complete!
                     $completed = true;
                 } else {
-                    if (!$content_range) {
+                    if (! $content_range) {
                         // The file is incomplete and it's not a chunked upload, abort
                         $this->filesystem->unlink($file_path);
                         $file->error = 'abort';
@@ -398,7 +398,7 @@ class FileUpload
     {
         $name = trim(basename(stripslashes($name)), ".\x00..\x20");
 
-        if (!$name) {
+        if (! $name) {
             $name = str_replace('.', '-', microtime(true));
         }
 
@@ -465,7 +465,7 @@ class FileUpload
         // Now that we passed basic, implementation-agnostic tests,
         // let's do custom validators
         foreach ($this->validators as $validator) {
-            if (!$validator->validate($file, $current_size)) {
+            if (! $validator->validate($file, $current_size)) {
                 return false;
             }
         }
@@ -483,7 +483,7 @@ class FileUpload
      */
     protected function processCallbacksFor($eventName, File $file)
     {
-        if (!array_key_exists($eventName, $this->callbacks) || empty($this->callbacks[$eventName])) {
+        if (! array_key_exists($eventName, $this->callbacks) || empty($this->callbacks[$eventName])) {
             return;
         }
 
@@ -574,12 +574,12 @@ class FileUpload
      */
     protected function getNewHeaders(array $files, $content_range)
     {
-        $headers = array(
+        $headers = [
             'pragma' => 'no-cache',
             'cache-control' => 'no-store, no-cache, must-revalidate',
             'content-disposition' => 'inline; filename="files.json"',
             'x-content-type-options' => 'nosniff'
-        );
+        ];
 
         if ($content_range && is_object($files[0]) && isset($files[0]->size) && $files[0]->size) {
             $headers['range'] = '0-' . ($this->fixIntegerOverflow($files[0]->size) - 1);

--- a/src/FileUpload/FileUploadFactory.php
+++ b/src/FileUpload/FileUploadFactory.php
@@ -2,8 +2,8 @@
 
 namespace FileUpload;
 
-use FileUpload\PathResolver\PathResolver;
 use FileUpload\FileSystem\FileSystem;
+use FileUpload\PathResolver\PathResolver;
 use FileUpload\Validator\Validator;
 
 class FileUploadFactory
@@ -35,7 +35,7 @@ class FileUploadFactory
     public function __construct(
         PathResolver $pathresolver,
         FileSystem $filesystem,
-        $validators = array()
+        $validators = []
     ) {
         $this->pathresolver = $pathresolver;
         $this->filesystem = $filesystem;

--- a/src/FileUpload/Util.php
+++ b/src/FileUpload/Util.php
@@ -20,12 +20,12 @@ class Util
     public static function humanReadableToBytes($input)
     {
         $number = (int)$input;
-        $units = array(
+        $units = [
             'b' => 1,
             'k' => 1024,
             'm' => 1048576,
             'g' => 1073741824
-        );
+        ];
         $unit = strtolower(substr($input, -1));
         if (isset($units[$unit])) {
             return ($number * $units[$unit]);

--- a/src/FileUpload/Validator/DimensionValidator.php
+++ b/src/FileUpload/Validator/DimensionValidator.php
@@ -18,7 +18,7 @@ class DimensionValidator implements Validator
 
     protected $config;
 
-    protected $errorMessages = array(
+    protected $errorMessages = [
 
         self::INVALID_UPLOADED_FILE_TYPE => "Cannot validate the currently uploaded file by it's dimension as it is not an image",
 
@@ -33,7 +33,7 @@ class DimensionValidator implements Validator
         self::MIN_WIDTH => "The uploaded file's width is too small. It should have a minimum height of {value}",
 
         self::MAX_WIDTH => "The uploaded file's width is too large. It should have a maximum height of {value}"
-    );
+    ];
 
     public function __construct(array $config)
     {
@@ -50,7 +50,7 @@ class DimensionValidator implements Validator
     public function validate(File $file, $currentSize = null)
     {
 
-        if (!$file->isImage() || !list($width, $height) = getimagesize($file->getRealPath())) {
+        if (! $file->isImage() || ! list($width, $height) = getimagesize($file->getRealPath())) {
             $file->error = $this->errorMessages[self::INVALID_UPLOADED_FILE_TYPE];
 
             return false;

--- a/src/FileUpload/Validator/MimeTypeValidator.php
+++ b/src/FileUpload/Validator/MimeTypeValidator.php
@@ -25,9 +25,9 @@ class MimeTypeValidator implements Validator
      * Default error message for this Validator
      * @var array
      */
-    protected $errorMessages = array(
+    protected $errorMessages = [
         self::INVALID_MIMETYPE => "The uploaded filetype (mimetype) is invalid"
-    );
+    ];
 
     public function __construct(array $validMimeTypes)
     {
@@ -51,7 +51,7 @@ class MimeTypeValidator implements Validator
      */
     public function validate(File $file, $currentSize = null)
     {
-        if (!in_array($file->getMimeType(), $this->mimeTypes)) {
+        if (! in_array($file->getMimeType(), $this->mimeTypes)) {
             $this->isValid = false;
             $file->error = $this->errorMessages[self::INVALID_MIMETYPE];
         }

--- a/src/FileUpload/Validator/Simple.php
+++ b/src/FileUpload/Validator/Simple.php
@@ -26,16 +26,16 @@ class Simple implements Validator
      * Error messages
      * @var array
      */
-    protected $messages = array(
+    protected $messages = [
         self::UPLOAD_ERR_BAD_TYPE => 'Filetype not allowed',
         self::UPLOAD_ERR_TOO_LARGE => 'Filesize too large',
-    );
+    ];
 
     /**
      * @param integer $max_size
      * @param array   $allowed_types
      */
-    public function __construct($max_size, array $allowed_types = array())
+    public function __construct($max_size, array $allowed_types = [])
     {
         $this->setMaxSize($max_size);
         $this->allowed_types = $allowed_types;
@@ -75,8 +75,8 @@ class Simple implements Validator
      */
     public function validate(File $file, $current_size = null)
     {
-        if (!empty($this->allowed_types)) {
-            if (!in_array($file->getMimeType(), $this->allowed_types)) {
+        if (! empty($this->allowed_types)) {
+            if (! in_array($file->getMimeType(), $this->allowed_types)) {
                 $file->error = $this->messages[self::UPLOAD_ERR_BAD_TYPE];
 
                 return false;

--- a/src/FileUpload/Validator/SizeValidator.php
+++ b/src/FileUpload/Validator/SizeValidator.php
@@ -26,10 +26,10 @@ class SizeValidator implements Validator
      */
     protected $isValid;
 
-    protected $errorMessages = array(
+    protected $errorMessages = [
         self::FILE_SIZE_IS_TOO_LARGE => "The uploaded file is too large",
         self::FILE_SIZE_IS_TOO_SMALL => "The uploaded file is too small"
-    );
+    ];
 
     /**
      * @param int $maxSize
@@ -44,8 +44,8 @@ class SizeValidator implements Validator
 
     /**
      * @param $maxSize
-     * @return int|string
      * @throws \Exception if the max file size is null or equals zero
+     * @return int|string
      */
     public function setMaxSize($maxSize)
     {
@@ -67,8 +67,8 @@ class SizeValidator implements Validator
 
     /**
      * @param $minSize
-     * @return int|string
      * @throws \Exception if the file size is lesser than zero or null
+     * @return int|string
      */
     public function setMinFile($minSize)
     {

--- a/tests/FileUpload/FileNameGenerator/CustomTest.php
+++ b/tests/FileUpload/FileNameGenerator/CustomTest.php
@@ -5,10 +5,10 @@ namespace FileUpload\FileNameGenerator;
 use FileUpload\FileSystem\Mock;
 use FileUpload\FileUpload;
 use FileUpload\PathResolver\Simple;
+use PHPUnit\Framework\TestCase;
 
-class CustomTest extends \PHPUnit_Framework_TestCase
+class CustomTest extends TestCase
 {
-
     public function testStringGenerator()
     {
         $customName = "my_file.jpg";
@@ -20,14 +20,13 @@ class CustomTest extends \PHPUnit_Framework_TestCase
         $filename = $customName;
         $new_filename = $customName;
 
-        $server = array('CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321);
-        $file = array(
-            'tmp_name' => $playground_path . '/real-image.jpg',
-            'name' => 'real-image.jpg',
-            'size' => 30321,
-            'type' => 'image/jpg',
-            'error' => 0
-        );
+        $server = ['CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321 ];
+        $file = [
+          'tmp_name' => $playground_path . '/real-image.jpg',
+          'name' => 'real-image.jpg',
+          'size' => 30321,
+          'type' => 'image/jpg',
+          'error' => 0 ];
 
         $fileUpload = new FileUpload($file, $server, $generator);
 
@@ -35,9 +34,9 @@ class CustomTest extends \PHPUnit_Framework_TestCase
         $fileUpload->setPathResolver(new Simple($playground_path . "/uploaded"));
 
         $this->assertEquals(
-            $generator->getFileName($filename, "image/jpg", "asdf.jpg", 0, "100", $fileUpload), $new_filename
+            $generator->getFileName($filename, "image/jpg", "asdf.jpg", 0, "100", $fileUpload),
+            $new_filename
         );
-
     }
 
     public function testClosureGenerator()
@@ -52,14 +51,13 @@ class CustomTest extends \PHPUnit_Framework_TestCase
 
         $filename = "picture.jpg";
 
-        $server = array('CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321);
-        $file = array(
-            'tmp_name' => $playground_path . '/real-image.jpg',
+        $server = [ 'CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321 ];
+        $file = ['tmp_name' => $playground_path . '/real-image.jpg',
             'name' => 'real-image.jpg',
             'size' => 30321,
             'type' => 'image/jpg',
             'error' => 0
-        );
+        ];
 
         $fileUpload = new FileUpload($file, $server, $generator);
 
@@ -69,14 +67,15 @@ class CustomTest extends \PHPUnit_Framework_TestCase
         $new_filename = $customName($filename, "image/jpg", "asdf.jpg", 0, "100", $fileUpload);
 
         $this->assertEquals(
-            $generator->getFileName($filename, "image/jpg", "asdf.jpg", 0, "100", $fileUpload), $new_filename
+            $generator->getFileName($filename, "image/jpg", "asdf.jpg", 0, "100", $fileUpload),
+            $new_filename
         );
     }
 
     public function testCallableGenerator()
     {
-
-        function generateName() {
+        function generateName()
+        {
             return func_get_arg(0);
         }
 
@@ -86,14 +85,12 @@ class CustomTest extends \PHPUnit_Framework_TestCase
 
         $filename = "picture.jpg";
 
-        $server = array('CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321);
-        $file = array(
-            'tmp_name' => $playground_path . '/real-image.jpg',
+        $server = ['CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321];
+        $file = [ 'tmp_name' => $playground_path . '/real-image.jpg',
             'name' => 'real-image.jpg',
             'size' => 30321,
             'type' => 'image/jpg',
-            'error' => 0
-        );
+            'error' => 0];
 
         $fileUpload = new FileUpload($file, $server, $generator);
 
@@ -103,7 +100,8 @@ class CustomTest extends \PHPUnit_Framework_TestCase
         $new_filename = generateName($filename, "image/jpg", "asdf.jpg", 0, "100", $fileUpload);
 
         $this->assertEquals(
-            $generator->getFileName($filename, "image/jpg", "asdf.jpg", 0, "100", $fileUpload), $new_filename
+            $generator->getFileName($filename, "image/jpg", "asdf.jpg", 0, "100", $fileUpload),
+            $new_filename
         );
     }
 }

--- a/tests/FileUpload/FileNameGenerator/MD5Test.php
+++ b/tests/FileUpload/FileNameGenerator/MD5Test.php
@@ -16,11 +16,11 @@ class MD5Test extends TestCase
         $playground_path = __DIR__ . '/../../playground';
         $fixtures_path = __DIR__ . '/../../fixtures';
 
-        if (!is_dir($playground_path)) {
+        if (! is_dir($playground_path)) {
             mkdir($playground_path);
         }
 
-        if (!is_dir($playground_path . '/uploaded')) {
+        if (! is_dir($playground_path . '/uploaded')) {
             mkdir($playground_path . '/uploaded');
         }
 

--- a/tests/FileUpload/FileNameGenerator/MD5Test.php
+++ b/tests/FileUpload/FileNameGenerator/MD5Test.php
@@ -5,8 +5,9 @@ namespace FileUpload\FileNameGenerator;
 use FileUpload\FileSystem\Mock;
 use FileUpload\FileUpload;
 use FileUpload\PathResolver\Simple as Path;
+use PHPUnit\Framework\TestCase;
 
-class MD5Test extends \PHPUnit_Framework_TestCase
+class MD5Test extends TestCase
 {
     protected $filesystem;
 
@@ -38,29 +39,28 @@ class MD5Test extends \PHPUnit_Framework_TestCase
 
     public function testGenerator()
     {
-
         $generator = new MD5();
         $playground_path = __DIR__ . '/../playground';
 
         $filename = "picture.jpg";
         $new_filename = md5("picture") . ".jpg";
 
-        $server = array('CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321);
-        $file = array(
-            'tmp_name' => $playground_path . '/real-image.jpg',
-            'name' => 'real-image.jpg',
-            'size' => 30321,
-            'type' => 'image/jpg',
-            'error' => 0
-        );
+        $server = [ 'CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321 ];
+	$file = [ 'tmp_name' => $playground_path . '/real-image.jpg',
+		'name' => 'real-image.jpg',
+		'size' => 30321,
+		'type' => 'image/jpg',
+		'error' => 0
+	];
 
         $fileUpload = new FileUpload($file, $server, $generator);
         $fileUpload->setFileSystem(new Mock());
         $fileUpload->setPathResolver(new Path($playground_path . "/uploaded"));
 
-        $this->assertEquals($generator->getFileName($filename, "image/jpg", "asdf.jpg", 0, "100", $fileUpload),
-            $new_filename);
-
+        $this->assertEquals(
+            $generator->getFileName($filename, "image/jpg", "asdf.jpg", 0, "100", $fileUpload),
+            $new_filename
+        );
     }
 
     public function testUploadFailsBecauseFileAlreadyExistsOnTheFileSystem()
@@ -70,14 +70,13 @@ class MD5Test extends \PHPUnit_Framework_TestCase
 
         $filename = "real-image.jpg";
 
-        $server = array('CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321);
-        $file = array(
-            'tmp_name' => $playground_path . '/uploaded/real-image.jpg',
-            'name' => 'real-image.jpg',
-            'size' => 30321,
-            'type' => 'image/jpg',
-            'error' => 0
-        );
+        $server = [ 'CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321 ];
+	$file = [ 'tmp_name' => $playground_path . '/uploaded/real-image.jpg',
+		'name' => 'real-image.jpg',
+		'size' => 30321,
+		'type' => 'image/jpg',
+		'error' => 0
+	];
 
         $fileUpload = new FileUpload($file, $server, $generator);
         $fileUpload->setFileSystem(new Mock());
@@ -97,14 +96,13 @@ class MD5Test extends \PHPUnit_Framework_TestCase
         $filename = "real-image.jpg";
         $newFileName = md5("real-image") . '.jpg';
 
-        $server = array('CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321);
-        $file = array(
-            'tmp_name' => $playground_path . '/uploaded/real-image.jpg',
-            'name' => 'real-image.jpg',
-            'size' => 30321,
-            'type' => 'image/jpg',
-            'error' => 0
-        );
+        $server = [ 'CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321 ];
+	$file = [ 'tmp_name' => $playground_path . '/uploaded/real-image.jpg',
+		'name' => 'real-image.jpg',
+		'size' => 30321,
+		'type' => 'image/jpg',
+		'error' => 0
+	];
 
         $fileUpload = new FileUpload($file, $server, $generator);
         $fileUpload->setFileSystem(new Mock());

--- a/tests/FileUpload/FileNameGenerator/RandomTest.php
+++ b/tests/FileUpload/FileNameGenerator/RandomTest.php
@@ -5,19 +5,12 @@ namespace FileUpload\FileNameGenerator;
 use FileUpload\FileSystem\Mock;
 use FileUpload\PathResolver\Simple;
 use FileUpload\FileUpload;
+use PHPUnit\Framework\TestCase;
 
-class RandomTest extends \PHPUnit_Framework_TestCase
+class RandomTest extends TestCase
 {
-    protected $filesystem;
-
-    public function setUp()
-    {
-
-    }
-
     public function testGenerator()
     {
-
         $generator = new Random(32);
 
         $playground_path = __DIR__ . '/../playground';
@@ -29,7 +22,7 @@ class RandomTest extends \PHPUnit_Framework_TestCase
         $server = array('CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321);
         $file   = array('tmp_name' => $playground_path . '/real-image.jpg', 'name' => 'real-image.jpg', 'size' => 30321, 'type' => 'image/jpg', 'error' => 0);
 
-        $fileUpload = new FileUpload($file , $server , $generator);
+        $fileUpload = new FileUpload($file, $server, $generator);
         $fileUpload->setPathResolver($resolver);
         $fileUpload->setFileSystem($filesystem);
 
@@ -37,9 +30,5 @@ class RandomTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(32, strrpos($new_name, "."));
         $this->assertEquals(substr($new_name, strrpos($new_name, ".")), ".jpg");
-
     }
-
-
-
 }

--- a/tests/FileUpload/FileNameGenerator/RandomTest.php
+++ b/tests/FileUpload/FileNameGenerator/RandomTest.php
@@ -3,8 +3,8 @@
 namespace FileUpload\FileNameGenerator;
 
 use FileUpload\FileSystem\Mock;
-use FileUpload\PathResolver\Simple;
 use FileUpload\FileUpload;
+use FileUpload\PathResolver\Simple;
 use PHPUnit\Framework\TestCase;
 
 class RandomTest extends TestCase
@@ -17,10 +17,10 @@ class RandomTest extends TestCase
         $filename = "picture.jpg";
 
         $filesystem = new Mock();
-        $resolver   = new Simple($playground_path . '/uploaded');
+        $resolver = new Simple($playground_path . '/uploaded');
 
-        $server = array('CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321);
-        $file   = array('tmp_name' => $playground_path . '/real-image.jpg', 'name' => 'real-image.jpg', 'size' => 30321, 'type' => 'image/jpg', 'error' => 0);
+        $server = ['CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321];
+        $file = ['tmp_name' => $playground_path . '/real-image.jpg', 'name' => 'real-image.jpg', 'size' => 30321, 'type' => 'image/jpg', 'error' => 0];
 
         $fileUpload = new FileUpload($file, $server, $generator);
         $fileUpload->setPathResolver($resolver);

--- a/tests/FileUpload/FileNameGenerator/SimpleTest.php
+++ b/tests/FileUpload/FileNameGenerator/SimpleTest.php
@@ -6,19 +6,12 @@ use FileUpload\FileSystem\Mock;
 use FileUpload\FileUpload;
 use FileUpload\PathResolver\Simple;
 use FileUpload\FileNameGenerator\Simple as SimpleGenerator;
+use PHPUnit\Framework\TestCase;
 
-class SimpleTest extends \PHPUnit_Framework_TestCase
+class SimpleTest extends TestCase
 {
-    protected $filesystem;
-
-    public function setUp()
-    {
-
-    }
-
     public function testGenerator()
     {
-
         $generator = new SimpleGenerator();
         $playground_path = __DIR__ . '/../playground';
 
@@ -28,14 +21,12 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
         $server = array('CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321);
         $file   = array('tmp_name' => $playground_path . '/real-image.jpg', 'name' => 'real-image.jpg', 'size' => 30321, 'type' => 'image/jpg', 'error' => 0);
 
-        $fileUpload = new FileUpload($file , $server , $generator);
+        $fileUpload = new FileUpload($file, $server, $generator);
         $fileUpload->setPathResolver($resolver);
         $fileUpload->setFileSystem($filesystem);
 
         $filename = "picture.jpg";
 
-        $this->assertEquals($generator->getFileName($filename, "image/jpg", "asdf.jpg", 0, 100 ,$fileUpload), $filename);
-
+        $this->assertEquals($generator->getFileName($filename, "image/jpg", "asdf.jpg", 0, 100, $fileUpload), $filename);
     }
-
 }

--- a/tests/FileUpload/FileNameGenerator/SimpleTest.php
+++ b/tests/FileUpload/FileNameGenerator/SimpleTest.php
@@ -2,10 +2,10 @@
 
 namespace FileUpload\FileNameGenerator;
 
+use FileUpload\FileNameGenerator\Simple as SimpleGenerator;
 use FileUpload\FileSystem\Mock;
 use FileUpload\FileUpload;
 use FileUpload\PathResolver\Simple;
-use FileUpload\FileNameGenerator\Simple as SimpleGenerator;
 use PHPUnit\Framework\TestCase;
 
 class SimpleTest extends TestCase
@@ -16,10 +16,10 @@ class SimpleTest extends TestCase
         $playground_path = __DIR__ . '/../playground';
 
         $filesystem = new Mock();
-        $resolver   = new Simple($playground_path . '/uploaded');
+        $resolver = new Simple($playground_path . '/uploaded');
 
-        $server = array('CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321);
-        $file   = array('tmp_name' => $playground_path . '/real-image.jpg', 'name' => 'real-image.jpg', 'size' => 30321, 'type' => 'image/jpg', 'error' => 0);
+        $server = ['CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321];
+        $file = ['tmp_name' => $playground_path . '/real-image.jpg', 'name' => 'real-image.jpg', 'size' => 30321, 'type' => 'image/jpg', 'error' => 0];
 
         $fileUpload = new FileUpload($file, $server, $generator);
         $fileUpload->setPathResolver($resolver);

--- a/tests/FileUpload/FileNameGenerator/SlugTest.php
+++ b/tests/FileUpload/FileNameGenerator/SlugTest.php
@@ -2,10 +2,10 @@
 
 namespace FileUpload\FileNameGenerator;
 
+use FileUpload\FileNameGenerator\Slug as SlugGenerator;
 use FileUpload\FileSystem\Mock;
 use FileUpload\FileUpload;
 use FileUpload\PathResolver\Simple;
-use FileUpload\FileNameGenerator\Slug as SlugGenerator;
 use PHPUnit\Framework\TestCase;
 
 class SlugTest extends TestCase
@@ -16,10 +16,10 @@ class SlugTest extends TestCase
         $playground_path = __DIR__ . '/../playground';
 
         $filesystem = new Mock();
-        $resolver   = new Simple($playground_path . '/uploaded');
+        $resolver = new Simple($playground_path . '/uploaded');
 
-        $server = array('CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321);
-        $file   = array('tmp_name' => $playground_path . '/real-image.jpg', 'name' => 'real-image.jpg', 'size' => 30321, 'type' => 'image/jpg', 'error' => 0);
+        $server = ['CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321];
+        $file = ['tmp_name' => $playground_path . '/real-image.jpg', 'name' => 'real-image.jpg', 'size' => 30321, 'type' => 'image/jpg', 'error' => 0];
 
         $fileUpload = new FileUpload($file, $server, $generator);
         $fileUpload->setPathResolver($resolver);

--- a/tests/FileUpload/FileNameGenerator/SlugTest.php
+++ b/tests/FileUpload/FileNameGenerator/SlugTest.php
@@ -6,19 +6,12 @@ use FileUpload\FileSystem\Mock;
 use FileUpload\FileUpload;
 use FileUpload\PathResolver\Simple;
 use FileUpload\FileNameGenerator\Slug as SlugGenerator;
+use PHPUnit\Framework\TestCase;
 
-class SlugTest extends \PHPUnit_Framework_TestCase
+class SlugTest extends TestCase
 {
-    protected $filesystem;
-
-    public function setUp()
-    {
-
-    }
-
     public function testGenerator()
     {
-
         $generator = new SlugGenerator();
         $playground_path = __DIR__ . '/../playground';
 
@@ -28,15 +21,13 @@ class SlugTest extends \PHPUnit_Framework_TestCase
         $server = array('CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321);
         $file   = array('tmp_name' => $playground_path . '/real-image.jpg', 'name' => 'real-image.jpg', 'size' => 30321, 'type' => 'image/jpg', 'error' => 0);
 
-        $fileUpload = new FileUpload($file , $server , $generator);
+        $fileUpload = new FileUpload($file, $server, $generator);
         $fileUpload->setPathResolver($resolver);
         $fileUpload->setFileSystem($filesystem);
 
         $filename = "Awesome Picture 2.jpg";
         $expectedFilename = "awesome-picture-2.jpg";
 
-        $this->assertEquals($generator->getFileName($filename, "image/jpg", "asdf.jpg", 0, 100 ,$fileUpload), $expectedFilename);
-
+        $this->assertEquals($generator->getFileName($filename, "image/jpg", "asdf.jpg", 0, 100, $fileUpload), $expectedFilename);
     }
-
 }

--- a/tests/FileUpload/FileSystem/SimpleTest.php
+++ b/tests/FileUpload/FileSystem/SimpleTest.php
@@ -11,7 +11,7 @@ class SimpleTest extends TestCase
     public function setUp()
     {
         $playground_path = __DIR__ . '/../../playground';
-        $fixtures_path   = __DIR__ . '/../../fixtures';
+        $fixtures_path = __DIR__ . '/../../fixtures';
 
         $this->filesystem = new Simple();
 
@@ -39,7 +39,7 @@ class SimpleTest extends TestCase
     public function testWriteToFile()
     {
         $yadda = __DIR__ . '/../../playground/yadda.txt';
-        $path  = __DIR__ . '/../../playground/test.1.txt';
+        $path = __DIR__ . '/../../playground/test.1.txt';
 
         $this->filesystem->writeToFile($path, $this->filesystem->getFileStream($yadda));
         $this->assertEquals(file_get_contents($yadda), file_get_contents($path));
@@ -50,7 +50,7 @@ class SimpleTest extends TestCase
     public function testMoveUploadedFile()
     {
         $yadda = __DIR__ . '/../../playground/yadda.txt';
-        $path  = __DIR__ . '/../../playground/test.2.txt';
+        $path = __DIR__ . '/../../playground/test.2.txt';
 
         $original_yadda = file_get_contents($yadda);
 

--- a/tests/FileUpload/FileSystem/SimpleTest.php
+++ b/tests/FileUpload/FileSystem/SimpleTest.php
@@ -2,57 +2,66 @@
 
 namespace FileUpload\FileSystem;
 
-class SimpleTest extends \PHPUnit_Framework_TestCase {
-  protected $filesystem;
+use PHPUnit\Framework\TestCase;
 
-  public function setUp() {
-    $playground_path = __DIR__ . '/../../playground';
-    $fixtures_path   = __DIR__ . '/../../fixtures';
+class SimpleTest extends TestCase
+{
+    protected $filesystem;
 
-    $this->filesystem = new Simple();
+    public function setUp()
+    {
+        $playground_path = __DIR__ . '/../../playground';
+        $fixtures_path   = __DIR__ . '/../../fixtures';
 
-    if(! is_dir($playground_path)) {
-      mkdir($playground_path);
+        $this->filesystem = new Simple();
+
+        if (! is_dir($playground_path)) {
+            mkdir($playground_path);
+        }
+
+        if (! is_file($playground_path . '/yadda.txt')) {
+            copy($fixtures_path . '/yadda.txt', $playground_path . '/yadda.txt');
+        }
     }
 
-    if(! is_file($playground_path . '/yadda.txt')) {
-      copy($fixtures_path . '/yadda.txt', $playground_path . '/yadda.txt');
+    public function testIsFile()
+    {
+        $this->assertTrue($this->filesystem->isFile(__DIR__ . '/../../fixtures/real-image.jpg'));
+        $this->assertFalse($this->filesystem->isFile(__DIR__ . '/../../fixtures'));
     }
-  }
 
-  public function testIsFile() {
-    $this->assertTrue($this->filesystem->isFile(__DIR__ . '/../../fixtures/real-image.jpg'));
-    $this->assertFalse($this->filesystem->isFile(__DIR__ . '/../../fixtures'));
-  }
+    public function testIsDir()
+    {
+        $this->assertFalse($this->filesystem->isDir(__DIR__ . '/../../fixtures/real-image.jpg'));
+        $this->assertTrue($this->filesystem->isDir(__DIR__ . '/../../fixtures'));
+    }
 
-  public function testIsDir() {
-    $this->assertFalse($this->filesystem->isDir(__DIR__ . '/../../fixtures/real-image.jpg'));
-    $this->assertTrue($this->filesystem->isDir(__DIR__ . '/../../fixtures'));
-  }
+    public function testWriteToFile()
+    {
+        $yadda = __DIR__ . '/../../playground/yadda.txt';
+        $path  = __DIR__ . '/../../playground/test.1.txt';
 
-  public function testWriteToFile() {
-    $yadda = __DIR__ . '/../../playground/yadda.txt';
-    $path  = __DIR__ . '/../../playground/test.1.txt';
+        $this->filesystem->writeToFile($path, $this->filesystem->getFileStream($yadda));
+        $this->assertEquals(file_get_contents($yadda), file_get_contents($path));
 
-    $this->filesystem->writeToFile($path, $this->filesystem->getFileStream($yadda));
-    $this->assertEquals(file_get_contents($yadda), file_get_contents($path));
+        $this->filesystem->unlink($path);
+    }
 
-    $this->filesystem->unlink($path);
-  }
+    public function testMoveUploadedFile()
+    {
+        $yadda = __DIR__ . '/../../playground/yadda.txt';
+        $path  = __DIR__ . '/../../playground/test.2.txt';
 
-  public function testMoveUploadedFile() {
-    $yadda = __DIR__ . '/../../playground/yadda.txt';
-    $path  = __DIR__ . '/../../playground/test.2.txt';
+        $original_yadda = file_get_contents($yadda);
 
-    $original_yadda = file_get_contents($yadda);
+        $this->filesystem->moveUploadedFile($yadda, $path);
+        $this->assertEquals($original_yadda, file_get_contents($path));
 
-    $this->filesystem->moveUploadedFile($yadda, $path);
-    $this->assertEquals($original_yadda, file_get_contents($path));
+        $this->filesystem->moveUploadedFile($path, $yadda);
+    }
 
-    $this->filesystem->moveUploadedFile($path, $yadda);
-  }
-
-  public function testGetFilesize() {
-    $this->assertEquals(20 * 1024, $this->filesystem->getFilesize(__DIR__ . '/../../fixtures/blob'));
-  }
+    public function testGetFilesize()
+    {
+        $this->assertEquals(20 * 1024, $this->filesystem->getFilesize(__DIR__ . '/../../fixtures/blob'));
+    }
 }

--- a/tests/FileUpload/FileTest.php
+++ b/tests/FileUpload/FileTest.php
@@ -2,7 +2,9 @@
 
 namespace FileUpload;
 
-class FileTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class FileTest extends TestCase
 {
     public function testImagePositiveDetermination()
     {

--- a/tests/FileUpload/FileUploadFactoryTest.php
+++ b/tests/FileUpload/FileUploadFactoryTest.php
@@ -2,11 +2,15 @@
 
 namespace FileUpload;
 
-class FileUploadFactoryTest extends \PHPUnit_Framework_TestCase {
-  public function testCreate() {
-    $factory  = new FileUploadFactory(new PathResolver\Simple(''), new FileSystem\Mock());
-    $instance = $factory->create(array(), array());
+use PHPUnit\Framework\TestCase;
 
-    $this->assertTrue($instance instanceof FileUpload);
-  }
+class FileUploadFactoryTest extends TestCase
+{
+    public function testCreate()
+    {
+        $factory  = new FileUploadFactory(new PathResolver\Simple(''), new FileSystem\Mock());
+        $instance = $factory->create(array(), array());
+
+        $this->assertTrue($instance instanceof FileUpload);
+    }
 }

--- a/tests/FileUpload/FileUploadFactoryTest.php
+++ b/tests/FileUpload/FileUploadFactoryTest.php
@@ -8,8 +8,8 @@ class FileUploadFactoryTest extends TestCase
 {
     public function testCreate()
     {
-        $factory  = new FileUploadFactory(new PathResolver\Simple(''), new FileSystem\Mock());
-        $instance = $factory->create(array(), array());
+        $factory = new FileUploadFactory(new PathResolver\Simple(''), new FileSystem\Mock());
+        $instance = $factory->create([], []);
 
         $this->assertTrue($instance instanceof FileUpload);
     }

--- a/tests/FileUpload/FileUploadTest.php
+++ b/tests/FileUpload/FileUploadTest.php
@@ -2,52 +2,57 @@
 
 namespace FileUpload;
 
-class FileUploadTest extends \PHPUnit_Framework_TestCase {
-  public function setUp() {
-    $playground_path = __DIR__ . '/../playground';
-    $fixtures_path   = __DIR__ . '/../fixtures';
+use PHPUnit\Framework\TestCase;
 
-    if(! is_dir($playground_path)) {
-      mkdir($playground_path);
+class FileUploadTest extends TestCase
+{
+    public function setUp()
+    {
+        $playground_path = __DIR__ . '/../playground';
+        $fixtures_path   = __DIR__ . '/../fixtures';
+
+        if (! is_dir($playground_path)) {
+            mkdir($playground_path);
+        }
+
+        if (! is_dir($playground_path . '/uploaded')) {
+            mkdir($playground_path . '/uploaded');
+        }
+
+        if (! is_file($playground_path . '/real-image.jpg')) {
+            copy($fixtures_path . '/real-image.jpg', $playground_path . '/real-image.jpg');
+        }
+
+        if (is_file($playground_path . '/uploaded/real-image.jpg')) {
+            unlink($playground_path . '/uploaded/real-image.jpg');
+        }
     }
 
-    if(! is_dir($playground_path . '/uploaded')) {
-      mkdir($playground_path . '/uploaded');
+    public function testSingleUpload()
+    {
+        $playground_path = __DIR__ . '/../playground';
+
+        $server = array('CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321);
+        $file   = array('tmp_name' => $playground_path . '/real-image.jpg', 'name' => 'real-image.jpg', 'size' => 30321, 'type' => 'image/jpg', 'error' => 0);
+
+        $filesystem = new FileSystem\Mock();
+        $resolver   = new PathResolver\Simple($playground_path . '/uploaded');
+        $uploader   = new FileUpload($file, $server);
+        $test       = false;
+
+        $uploader->setPathResolver($resolver);
+        $uploader->setFileSystem($filesystem);
+
+        $uploader->addCallback('completed', function () use (&$test) {
+            $test = true;
+        });
+
+        list($files, $headers) = $uploader->processAll();
+
+        $this->assertCount(1, $files, 'Files array should contain one file');
+        $this->assertEquals(0, $files[0]->error, 'Uploaded file should not have errors');
+        $this->assertTrue($test, 'Complete callback should set $test to true');
     }
 
-    if(! is_file($playground_path . '/real-image.jpg')) {
-      copy($fixtures_path . '/real-image.jpg', $playground_path . '/real-image.jpg');
-    }
-
-    if(is_file($playground_path . '/uploaded/real-image.jpg')) {
-      unlink($playground_path . '/uploaded/real-image.jpg');
-    }
-  }
-
-  public function testSingleUpload() {
-    $playground_path = __DIR__ . '/../playground';
-
-    $server = array('CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321);
-    $file   = array('tmp_name' => $playground_path . '/real-image.jpg', 'name' => 'real-image.jpg', 'size' => 30321, 'type' => 'image/jpg', 'error' => 0);
-
-    $filesystem = new FileSystem\Mock();
-    $resolver   = new PathResolver\Simple($playground_path . '/uploaded');
-    $uploader   = new FileUpload($file, $server);
-    $test       = false;
-
-    $uploader->setPathResolver($resolver);
-    $uploader->setFileSystem($filesystem);
-
-    $uploader->addCallback('completed', function () use (&$test) {
-      $test = true;
-    });
-
-    list($files, $headers) = $uploader->processAll();
-
-    $this->assertCount(1, $files, 'Files array should contain one file');
-    $this->assertEquals(0, $files[0]->error, 'Uploaded file should not have errors');
-    $this->assertTrue($test, 'Complete callback should set $test to true');
-  }
-
-  // TODO: Tests for multiple uploads, chunked uploads, aborted uploads
+    // TODO: Tests for multiple uploads, chunked uploads, aborted uploads
 }

--- a/tests/FileUpload/FileUploadTest.php
+++ b/tests/FileUpload/FileUploadTest.php
@@ -9,7 +9,7 @@ class FileUploadTest extends TestCase
     public function setUp()
     {
         $playground_path = __DIR__ . '/../playground';
-        $fixtures_path   = __DIR__ . '/../fixtures';
+        $fixtures_path = __DIR__ . '/../fixtures';
 
         if (! is_dir($playground_path)) {
             mkdir($playground_path);
@@ -32,13 +32,13 @@ class FileUploadTest extends TestCase
     {
         $playground_path = __DIR__ . '/../playground';
 
-        $server = array('CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321);
-        $file   = array('tmp_name' => $playground_path . '/real-image.jpg', 'name' => 'real-image.jpg', 'size' => 30321, 'type' => 'image/jpg', 'error' => 0);
+        $server = ['CONTENT_TYPE' => 'image/jpg', 'CONTENT_LENGTH' => 30321];
+        $file = ['tmp_name' => $playground_path . '/real-image.jpg', 'name' => 'real-image.jpg', 'size' => 30321, 'type' => 'image/jpg', 'error' => 0];
 
         $filesystem = new FileSystem\Mock();
-        $resolver   = new PathResolver\Simple($playground_path . '/uploaded');
-        $uploader   = new FileUpload($file, $server);
-        $test       = false;
+        $resolver = new PathResolver\Simple($playground_path . '/uploaded');
+        $uploader = new FileUpload($file, $server);
+        $test = false;
 
         $uploader->setPathResolver($resolver);
         $uploader->setFileSystem($filesystem);

--- a/tests/FileUpload/PathResolver/SimpleTest.php
+++ b/tests/FileUpload/PathResolver/SimpleTest.php
@@ -2,15 +2,20 @@
 
 namespace FileUpload\PathResolver;
 
-class SimpleTest extends \PHPUnit_Framework_TestCase {
-  public function testUploadPath() {
-    $resolver = new Simple(__DIR__ . '/../../fixtures');
-    $this->assertEquals(__DIR__ . '/../../fixtures/real-image.jpg', $resolver->getUploadPath('real-image.jpg'));
-  }
+use PHPUnit\Framework\TestCase;
 
-  public function testUpcountName() {
-    $resolver = new Simple(__DIR__ . '/../../fixtures');
-    $this->assertEquals('real-image (1).jpg', $resolver->upcountName('real-image.jpg'));
-    $this->assertEquals('real-image (2).jpg', $resolver->upcountName('real-image (1).jpg'));
-  }
+class SimpleTest extends TestCase
+{
+    public function testUploadPath()
+    {
+        $resolver = new Simple(__DIR__ . '/../../fixtures');
+        $this->assertEquals(__DIR__ . '/../../fixtures/real-image.jpg', $resolver->getUploadPath('real-image.jpg'));
+    }
+
+    public function testUpcountName()
+    {
+        $resolver = new Simple(__DIR__ . '/../../fixtures');
+        $this->assertEquals('real-image (1).jpg', $resolver->upcountName('real-image.jpg'));
+        $this->assertEquals('real-image (2).jpg', $resolver->upcountName('real-image (1).jpg'));
+    }
 }

--- a/tests/FileUpload/Validator/DimensionValidatorTest.php
+++ b/tests/FileUpload/Validator/DimensionValidatorTest.php
@@ -2,12 +2,11 @@
 
 namespace FileUpload\Validator;
 
-
+use PHPUnit\Framework\TestCase;
 use FileUpload\File;
 
-class DimensionValidatorTest extends \PHPUnit_Framework_TestCase
+class DimensionValidatorTest extends TestCase
 {
-
     protected $directory;
 
     public function testOnlyAnImageCanBeValidated()
@@ -270,7 +269,6 @@ class DimensionValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testSetErrorMessages()
     {
-
         $_FILES['file'] = array(
             "name" => "real-image.jpg",
             "tmp_name" => $this->directory . 'real-image.jpg',

--- a/tests/FileUpload/Validator/DimensionValidatorTest.php
+++ b/tests/FileUpload/Validator/DimensionValidatorTest.php
@@ -2,8 +2,8 @@
 
 namespace FileUpload\Validator;
 
-use PHPUnit\Framework\TestCase;
 use FileUpload\File;
+use PHPUnit\Framework\TestCase;
 
 class DimensionValidatorTest extends TestCase
 {
@@ -11,19 +11,19 @@ class DimensionValidatorTest extends TestCase
 
     public function testOnlyAnImageCanBeValidated()
     {
-        $_FILES['file'] = array(
+        $_FILES['file'] = [
             "name" => "fake-image.jpg",
             "tmp_name" => $this->directory . 'fake-image.jpg',
             "size" => 12,
             "error" => 0
-        );
+        ];
 
         $file = new File($_FILES['file']['tmp_name']);
 
-        $config = array(
+        $config = [
             'width' => 100,
             'height' => 200
-        );
+        ];
 
         $this->assertFalse(
             $this->createValidator($config)
@@ -43,27 +43,27 @@ class DimensionValidatorTest extends TestCase
 
     public function testValidatorWorksWithTheWidthConfig()
     {
-        $_FILES['file'] = array(
+        $_FILES['file'] = [
             "name" => "real-image.jpg",
             "tmp_name" => $this->directory . 'real-image.jpg',
             "size" => 12,
             "error" => 0
-        );
+        ];
 
         $file = new File($_FILES['file']['tmp_name']);
 
-        $config = array(
+        $config = [
             'width' => 300
-        );
+        ];
 
         $this->assertTrue(
             $this->createValidator($config)
                 ->validate($file, $_FILES['file']['size'])
         );
 
-        $config = array(
+        $config = [
             'width' => 302
-        );
+        ];
 
         $this->assertFalse(
             $this->createValidator($config)
@@ -73,27 +73,27 @@ class DimensionValidatorTest extends TestCase
 
     public function testValidatorWorksWithTheMinimumWidthConfig()
     {
-        $_FILES['file'] = array(
+        $_FILES['file'] = [
             "name" => "real-image.jpg",
             "tmp_name" => $this->directory . 'real-image.jpg',
             "size" => 12,
             "error" => 0
-        );
+        ];
 
         $file = new File($_FILES['file']['tmp_name']);
 
-        $config = array(
+        $config = [
             'min_width' => 200
-        );
+        ];
 
         $this->assertTrue(
             $this->createValidator($config)
                 ->validate($file, $_FILES['file']['size'])
         );
 
-        $config = array(
+        $config = [
             'min_width' => 301
-        );
+        ];
 
         $this->assertFalse(
             $this->createValidator($config)
@@ -103,27 +103,27 @@ class DimensionValidatorTest extends TestCase
 
     public function testValidatorWorksWithTheMaximumWidthConfig()
     {
-        $_FILES['file'] = array(
+        $_FILES['file'] = [
             "name" => "real-image.jpg",
             "tmp_name" => $this->directory . 'real-image.jpg',
             "size" => 12,
             "error" => 0
-        );
+        ];
 
         $file = new File($_FILES['file']['tmp_name']);
 
-        $config = array(
+        $config = [
             'max_width' => 400
-        );
+        ];
 
         $this->assertTrue(
             $this->createValidator($config)
                 ->validate($file, $_FILES['file']['size'])
         );
 
-        $config = array(
+        $config = [
             'max_width' => 250
-        );
+        ];
 
         $this->assertFalse(
             $this->createValidator($config)
@@ -133,19 +133,19 @@ class DimensionValidatorTest extends TestCase
 
     public function testValidatorWorksExpectedlyWithTheWidthAndHeightValues()
     {
-        $_FILES['file'] = array(
+        $_FILES['file'] = [
             "name" => "real-image.jpg",
             "tmp_name" => $this->directory . 'real-image.jpg',
             "size" => 12,
             "error" => 0
-        );
+        ];
 
         $file = new File($_FILES['file']['tmp_name']);
 
-        $config = array(
+        $config = [
             'width' => 300,
             'height' => 300
-        );
+        ];
 
         $this->assertTrue(
             $this->createValidator($config)
@@ -155,27 +155,27 @@ class DimensionValidatorTest extends TestCase
 
     public function testValidatorWorksWithTheHeightConfig()
     {
-        $_FILES['file'] = array(
+        $_FILES['file'] = [
             "name" => "real-image.jpg",
             "tmp_name" => $this->directory . 'real-image.jpg',
             "size" => 12,
             "error" => 0
-        );
+        ];
 
         $file = new File($_FILES['file']['tmp_name']);
 
-        $config = array(
+        $config = [
             'height' => 300
-        );
+        ];
 
         $this->assertTrue(
             $this->createValidator($config)
                 ->validate($file, $_FILES['file']['size'])
         );
 
-        $config = array(
+        $config = [
             'height' => 305
-        );
+        ];
 
         $this->assertFalse(
             $this->createValidator($config)
@@ -185,27 +185,27 @@ class DimensionValidatorTest extends TestCase
 
     public function testValidatorWorksWithTheMinimumHeightConfig()
     {
-        $_FILES['file'] = array(
+        $_FILES['file'] = [
             "name" => "real-image.jpg",
             "tmp_name" => $this->directory . 'real-image.jpg',
             "size" => 12,
             "error" => 0
-        );
+        ];
 
         $file = new File($_FILES['file']['tmp_name']);
 
-        $config = array(
+        $config = [
             'min_height' => 200
-        );
+        ];
 
         $this->assertTrue(
             $this->createValidator($config)
                 ->validate($file, $_FILES['file']['size'])
         );
 
-        $config = array(
+        $config = [
             'min_height' => 301
-        );
+        ];
 
         $this->assertFalse(
             $this->createValidator($config)
@@ -215,27 +215,27 @@ class DimensionValidatorTest extends TestCase
 
     public function testValidatorWorksWithTheMaximumHeightConfig()
     {
-        $_FILES['file'] = array(
+        $_FILES['file'] = [
             "name" => "real-image.jpg",
             "tmp_name" => $this->directory . 'real-image.jpg',
             "size" => 12,
             "error" => 0
-        );
+        ];
 
         $file = new File($_FILES['file']['tmp_name']);
 
-        $config = array(
+        $config = [
             'max_height' => 400
-        );
+        ];
 
         $this->assertTrue(
             $this->createValidator($config)
                 ->validate($file, $_FILES['file']['size'])
         );
 
-        $config = array(
+        $config = [
             'max_height' => 209
-        );
+        ];
 
         $this->assertFalse(
             $this->createValidator($config)
@@ -245,21 +245,21 @@ class DimensionValidatorTest extends TestCase
 
     public function testValidatorWorksAsExpectedWithAllConfigOption()
     {
-        $_FILES['file'] = array(
+        $_FILES['file'] = [
             "name" => "real-image.jpg",
             "tmp_name" => $this->directory . 'real-image.jpg',
             "size" => 12,
             "error" => 0
-        );
+        ];
 
         $file = new File($_FILES['file']['tmp_name']);
 
-        $config = array(
+        $config = [
             'width' => 300,
             'height' => 300,
             'max_width' => 310,
             'max_height' => 350
-        );
+        ];
 
         $this->assertTrue(
             $this->createValidator($config)
@@ -269,25 +269,25 @@ class DimensionValidatorTest extends TestCase
 
     public function testSetErrorMessages()
     {
-        $_FILES['file'] = array(
+        $_FILES['file'] = [
             "name" => "real-image.jpg",
             "tmp_name" => $this->directory . 'real-image.jpg',
             "size" => 12,
             "error" => 0
-        );
+        ];
 
         $file = new File($_FILES['file']['tmp_name']);
 
-        $config = array(
+        $config = [
             'width' => 301,
             'height' => 301
-        );
+        ];
 
         $validator = $this->createValidator($config);
 
-        $validator->setErrorMessages(array(
+        $validator->setErrorMessages([
             DimensionValidator::HEIGHT => "Height too large"
-        ));
+        ]);
 
         $validator->validate($file, $_FILES['file']['size']);
 

--- a/tests/FileUpload/Validator/MimeTypeValidatorTest.php
+++ b/tests/FileUpload/Validator/MimeTypeValidatorTest.php
@@ -3,10 +3,10 @@
 namespace FileUpload\Validator;
 
 use FileUpload\File;
+use PHPUnit\Framework\TestCase;
 
-class MimeTypeValidatorTest extends \PHPUnit_Framework_TestCase
+class MimeTypeValidatorTest extends TestCase
 {
-
     protected $directory;
 
     /**

--- a/tests/FileUpload/Validator/MimeTypeValidatorTest.php
+++ b/tests/FileUpload/Validator/MimeTypeValidatorTest.php
@@ -16,12 +16,12 @@ class MimeTypeValidatorTest extends TestCase
 
     public function testValidMimeType()
     {
-        $_FILES['file'] = array(
+        $_FILES['file'] = [
             "name" => "real-image.jpg",
             "tmp_name" => $this->directory . 'real-image.jpg',
             "size" => 12,
             "error" => 0
-        );
+        ];
 
         $file = new File($_FILES['file']['tmp_name']);
 
@@ -30,12 +30,12 @@ class MimeTypeValidatorTest extends TestCase
 
     public function testInvalidMimeType()
     {
-        $_FILES['file'] = array(
+        $_FILES['file'] = [
             "name" => "fake-image.jpg",
             "tmp_name" => $this->directory . 'fake-image.jpg',
             "size" => 12,
             "error" => 0
-        );
+        ];
 
         $file = new File($_FILES['file']['tmp_name']);
 
@@ -46,25 +46,25 @@ class MimeTypeValidatorTest extends TestCase
     {
         $this->directory = __DIR__ . '/../../fixtures/';
 
-        $this->validator = new MimeTypeValidator(array("image/jpeg"));
+        $this->validator = new MimeTypeValidator(["image/jpeg"]);
     }
 
     public function testSetErrorMessages()
     {
-        $_FILES['file'] = array(
+        $_FILES['file'] = [
             "name" => "fake-image.jpg",
             "tmp_name" => $this->directory . 'fake-image.jpg',
             "size" => 12,
             "error" => 0
-        );
+        ];
 
         $file = new File($_FILES['file']['tmp_name']);
 
         $errorMessage = "Invalid file type";
 
-        $this->validator->setErrorMessages(array(
+        $this->validator->setErrorMessages([
             0 => $errorMessage
-        ));
+        ]);
 
         $this->validator->validate($file, $_FILES['file']['size']);
 

--- a/tests/FileUpload/Validator/SimpleTest.php
+++ b/tests/FileUpload/Validator/SimpleTest.php
@@ -31,12 +31,12 @@ class SimpleTest extends TestCase
      */
     public function testFailMaxSize1A()
     {
-        $validator = new Simple("1A", array());
+        $validator = new Simple("1A", []);
     }
 
     public function testWrongMime()
     {
-        $validator = new Simple("1M", array('image/png'));
+        $validator = new Simple("1M", ['image/png']);
 
         $file = new File($_FILES['file']['tmp_name']);
 
@@ -46,7 +46,7 @@ class SimpleTest extends TestCase
 
     public function testOk()
     {
-        $validator = new Simple("40K", array('image/jpeg'));
+        $validator = new Simple("40K", ['image/jpeg']);
         $file = new File($_FILES['file']['tmp_name']);
 
         $this->assertTrue($validator->validate($file, $_FILES['file']['size']));
@@ -57,13 +57,13 @@ class SimpleTest extends TestCase
     {
         $file = new File($_FILES['file']['tmp_name']);
 
-        $validator = new Simple(10, array('image/png'));
+        $validator = new Simple(10, ['image/png']);
 
         $errorMessage = "Invalid file size";
 
-        $validator->setErrorMessages(array(
+        $validator->setErrorMessages([
             0 => $errorMessage
-        ));
+        ]);
 
         $validator->validate($file, $_FILES['file']['size']);
 
@@ -74,11 +74,11 @@ class SimpleTest extends TestCase
     {
         $this->directory = __DIR__ . '/../../fixtures/';
 
-        $_FILES['file'] = array(
+        $_FILES['file'] = [
             "name" => "real-image.jpg",
             "tmp_name" => $this->directory . 'real-image.jpg',
             "size" => 12,
             "error" => 0
-        );
+        ];
     }
 }

--- a/tests/FileUpload/Validator/SimpleTest.php
+++ b/tests/FileUpload/Validator/SimpleTest.php
@@ -3,8 +3,9 @@
 namespace FileUpload\Validator;
 
 use FileUpload\File;
+use PHPUnit\Framework\TestCase;
 
-class SimpleTest extends \PHPUnit_Framework_TestCase
+class SimpleTest extends TestCase
 {
     public function testExceedSize()
     {
@@ -35,7 +36,6 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
 
     public function testWrongMime()
     {
-
         $validator = new Simple("1M", array('image/png'));
 
         $file = new File($_FILES['file']['tmp_name']);
@@ -55,7 +55,6 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
 
     public function testSetErrorMessages()
     {
-
         $file = new File($_FILES['file']['tmp_name']);
 
         $validator = new Simple(10, array('image/png'));

--- a/tests/FileUpload/Validator/SizeValidatorTest.php
+++ b/tests/FileUpload/Validator/SizeValidatorTest.php
@@ -2,8 +2,8 @@
 
 namespace FileUpload\Validator;
 
-use PHPUnit\Framework\TestCase;
 use FileUpload\File;
+use PHPUnit\Framework\TestCase;
 
 class SizeValidatorTest extends TestCase
 {
@@ -15,12 +15,12 @@ class SizeValidatorTest extends TestCase
     {
         $this->directory = __DIR__ . '/../../fixtures/';
 
-        $_FILES['file'] = array(
+        $_FILES['file'] = [
             "name" => "real-image.jpg",
             "tmp_name" => $this->directory . 'real-image.jpg',
             "size" => 12,
             "error" => 0
-        );
+        ];
     }
 
     public function testNumericMaxSize()
@@ -68,9 +68,9 @@ class SizeValidatorTest extends TestCase
 
         $fileTooLarge = "Too Large";
 
-        $this->validator->setErrorMessages(array(
+        $this->validator->setErrorMessages([
             0 => $fileTooLarge
-        ));
+        ]);
 
         $this->assertFalse($this->validator->validate($file, $_FILES['file']['size']));
 
@@ -85,9 +85,9 @@ class SizeValidatorTest extends TestCase
 
         $fileTooSmall = "Too Small";
 
-        $this->validator->setErrorMessages(array(
+        $this->validator->setErrorMessages([
             1 => $fileTooSmall
-        ));
+        ]);
 
         $this->assertFalse($this->validator->validate($file, $_FILES['file']['size']));
 

--- a/tests/FileUpload/Validator/SizeValidatorTest.php
+++ b/tests/FileUpload/Validator/SizeValidatorTest.php
@@ -2,14 +2,14 @@
 
 namespace FileUpload\Validator;
 
-
+use PHPUnit\Framework\TestCase;
 use FileUpload\File;
 
-class SizeValidatorTest extends \PHPUnit_Framework_TestCase
+class SizeValidatorTest extends TestCase
 {
-	protected $directory;
-	protected $validator;
-	protected $file;
+    protected $directory;
+    protected $validator;
+    protected $file;
 
     protected function setUp()
     {
@@ -23,95 +23,92 @@ class SizeValidatorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-
     public function testNumericMaxSize()
-	{
-		$this->validator = new SizeValidator(pow(1024, 3));
+    {
+        $this->validator = new SizeValidator(pow(1024, 3));
 
         $file = new File($_FILES['file']['tmp_name']);
 
         $this->assertTrue($this->validator->validate($file, $_FILES['file']['size']));
-	}
+    }
 
-	public function testBetweenMinAndMaxSize()
-	{
-
-		$this->validator = new SizeValidator("40K", "10K");
+    public function testBetweenMinAndMaxSize()
+    {
+        $this->validator = new SizeValidator("40K", "10K");
 
         $file = new File($_FILES['file']['tmp_name']);
 
         $this->assertTrue($this->validator->validate($file, $_FILES['file']['size']));
-	}
+    }
 
 
-	public function testFileSizeTooLarge()
-	{
-		$this->validator = new SizeValidator("20K", 10);
-
-        $file = new File($_FILES['file']['tmp_name']);
-
-        $this->assertFalse($this->validator->validate($file, $_FILES['file']['size']));
-	}
-
-	public function testFileSizeTooSmall()
-	{
-		$this->validator = new SizeValidator("1M", "50k");
+    public function testFileSizeTooLarge()
+    {
+        $this->validator = new SizeValidator("20K", 10);
 
         $file = new File($_FILES['file']['tmp_name']);
 
         $this->assertFalse($this->validator->validate($file, $_FILES['file']['size']));
-	}
+    }
 
-	public function testSetMaximumErrorMessages()
-	{
-		$this->validator = new SizeValidator("29K", "10K");
-
-        $file = new File($_FILES['file']['tmp_name']);
-
-		$fileTooLarge = "Too Large";
-
-		$this->validator->setErrorMessages(array(
-			0 => $fileTooLarge
-		));
-
-		$this->assertFalse($this->validator->validate($file, $_FILES['file']['size']));
-
-		$this->assertEquals($fileTooLarge, $file->error);
-	}
-
-	public function testSetMinimumErrorMessages()
-	{
-		$this->validator = new SizeValidator("40K", "35K");
+    public function testFileSizeTooSmall()
+    {
+        $this->validator = new SizeValidator("1M", "50k");
 
         $file = new File($_FILES['file']['tmp_name']);
 
-		$fileTooSmall = "Too Small";
+        $this->assertFalse($this->validator->validate($file, $_FILES['file']['size']));
+    }
 
-		$this->validator->setErrorMessages(array(
-			1 => $fileTooSmall
-		));
+    public function testSetMaximumErrorMessages()
+    {
+        $this->validator = new SizeValidator("29K", "10K");
 
-		$this->assertFalse($this->validator->validate($file, $_FILES['file']['size']));
+        $file = new File($_FILES['file']['tmp_name']);
 
-		$this->assertEquals($fileTooSmall, $file->error);
-	}
+        $fileTooLarge = "Too Large";
 
-	/**
-	 * @expectedException \Exception
-	 * @expectedExceptionMessage Invalid File Max_Size
-	 */
-	public function testInvalidMaximumFileSize()
-	{
-		$this->validator = new SizeValidator("40A", 3);
-	}
+        $this->validator->setErrorMessages(array(
+            0 => $fileTooLarge
+        ));
 
-	/**
-	 * @expectedException \Exception
-	 * @expectedExceptionMessage Invalid File Min_Size
-	 */
-	public function testInvalidMinimumFilesSize()
-	{
-		$this->validator = new SizeValidator("40K", "-3");
-	}
+        $this->assertFalse($this->validator->validate($file, $_FILES['file']['size']));
 
+        $this->assertEquals($fileTooLarge, $file->error);
+    }
+
+    public function testSetMinimumErrorMessages()
+    {
+        $this->validator = new SizeValidator("40K", "35K");
+
+        $file = new File($_FILES['file']['tmp_name']);
+
+        $fileTooSmall = "Too Small";
+
+        $this->validator->setErrorMessages(array(
+            1 => $fileTooSmall
+        ));
+
+        $this->assertFalse($this->validator->validate($file, $_FILES['file']['size']));
+
+        $this->assertEquals($fileTooSmall, $file->error);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Invalid File Max_Size
+     */
+    public function testInvalidMaximumFileSize()
+    {
+        $this->validator = new SizeValidator("40A", 3);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Invalid File Min_Size
+     */
+    public function testInvalidMinimumFilesSize()
+    {
+        $this->validator = new SizeValidator("40K", "-3");
+    }
 }


### PR DESCRIPTION
Some time ago, I created https://github.com/Gargron/fileupload/issues/36  to update the supported versions.. https://github.com/Gargron/fileupload/issues/36#issuecomment-279240200 to update PHPUnit to a recent version .

This PR added no changes to the library as it is (has been ) stable enough..

> If I find enough time, Might go ahead with the Version 2, I proposed last year at #57 